### PR TITLE
fix: make npm MCP bin executable

### DIFF
--- a/packages/mcp-server/scripts/vendor-core.mjs
+++ b/packages/mcp-server/scripts/vendor-core.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,6 +17,7 @@ await cp(coreDist, vendoredCore, { recursive: true });
 
 await rewriteCoreImport(resolve(serverDist, "index.js"));
 await rewriteCoreImport(resolve(serverDist, "index.d.ts"));
+await chmod(resolve(serverDist, "index.js"), 0o755);
 
 async function assertFile(filePath, message) {
   const exists = await stat(filePath).then((info) => info.isFile(), () => false);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   addStorageGroups,
   addDynamicNodes,
@@ -549,9 +551,21 @@ function errorResult(message: string) {
   };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isCliEntryPoint()) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.stack ?? error.message : String(error));
     process.exit(1);
   });
+}
+
+function isCliEntryPoint(): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(entry);
+  } catch {
+    return fileURLToPath(import.meta.url) === entry;
+  }
 }


### PR DESCRIPTION
## Summary\n- make the generated MCP server bin executable in npm tarballs\n- make the CLI entrypoint guard work when npm runs the bin through a symlink\n\n## Verification\n- npm run build\n- npm test\n- npm run typecheck\n- npm pack -w @astandrik/local-ydb-mcp --pack-destination /tmp --json\n- MCP SDK smoke-test against /tmp/astandrik-local-ydb-mcp-0.2.0.tgz returned 27 tools