### PR TITLE
fix: allow publishing existing release tag

### DIFF
--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: true
         type: boolean
+      publish_tag:
+        description: Existing release tag to publish when dry_run is false, for example mcp-server-v0.5.0.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -69,6 +73,47 @@ jobs:
       - name: Publish ${{ needs.release-please.outputs.tag_name }} to npm
         run: npm publish -w @astandrik/local-ydb-mcp
 
+  publish-existing-release:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == false && inputs.publish_tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.publish_tag }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+
+      - name: Verify tag matches package version
+        env:
+          PUBLISH_TAG: ${{ inputs.publish_tag }}
+        run: |
+          package_version="$(node -p "require('./packages/mcp-server/package.json').version")"
+          expected_tag="mcp-server-v${package_version}"
+          if [ "${PUBLISH_TAG}" != "${expected_tag}" ]; then
+            echo "publish_tag must match package version: expected ${expected_tag}, got ${PUBLISH_TAG}" >&2
+            exit 1
+          fi
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm test
+
+      - run: npm run typecheck
+
+      - run: npm pack -w @astandrik/local-ydb-mcp --dry-run
+
+      - name: Publish ${{ inputs.publish_tag }} to npm
+        run: npm publish -w @astandrik/local-ydb-mcp
+
   dry-run:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
     runs-on: ubuntu-latest
@@ -76,6 +121,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.publish_tag || github.ref }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `publish_tag` workflow dispatch input and a new `publish-existing-release` job that checks out a specific git tag, verifies its version matches `package.json`, builds/tests/typechecks, and publishes to npm. It also updates the `dry-run` job to check out `publish_tag` (when provided) instead of always using `github.ref`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; findings are P2 quality-of-life concerns that do not affect the publish path itself.

No P0/P1 issues found. The new job correctly gates on dry_run == false && publish_tag != '', runs the same build/test/typecheck steps as the existing publish job, and verifies tag/version alignment before publishing. Two P2 observations: a silent no-op case when dry_run=false + publish_tag is empty, and an undocumented behaviour change in the dry-run checkout.

.github/workflows/publish-mcp-server.yml — review the silent no-op dispatch case and the updated dry-run checkout ref.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-mcp-server.yml | Adds `publish_tag` input and `publish-existing-release` job for re-publishing a previously tagged release; also updates `dry-run` checkout to respect `publish_tag`. Logic is sound; minor edge cases around silent no-op and dry-run ref change are noted. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[workflow_dispatch] --> B{dry_run?}
    B -- true --> C[dry-run job\ncheckout: publish_tag OR github.ref\nbuild / test / typecheck / pack --dry-run]
    B -- false --> D{publish_tag set?}
    D -- yes --> E[publish-existing-release job\ncheckout: publish_tag\nverify tag == package version\nbuild / test / typecheck / pack / PUBLISH]
    D -- no --> F[⚠️ No job runs — silent no-op]

    G[push to main] --> H[release-please job]
    H --> I{release_created?}
    I -- true --> J[publish job\ncheckout: HEAD\nbuild / test / typecheck / pack / PUBLISH]
    I -- false --> K[No publish]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Flocal-ydb-toolkit%22%20on%20the%20existing%20branch%20%22codex%2Fpublish-existing-release-tag%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fpublish-existing-release-tag%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fpublish-mcp-server.yml%3A77%0A**Silent%20no-op%20when%20%60dry_run%3Dfalse%60%20and%20%60publish_tag%60%20is%20empty**%0A%0AIf%20a%20user%20manually%20triggers%20the%20workflow%20with%20%60dry_run%3Dfalse%60%20but%20leaves%20%60publish_tag%60%20empty%2C%20neither%20%60publish-existing-release%60%20%28requires%20%60publish_tag%20!%3D%20''%60%29%20nor%20%60dry-run%60%20%28requires%20%60dry_run%20%3D%3D%20true%60%29%20runs%20%E2%80%94%20the%20dispatch%20silently%20succeeds%20with%20no%20jobs%20executed.%20This%20is%20likely%20surprising%20behaviour.%0A%0AConsider%20adding%20a%20validation%20job%20or%20a%20fallback%20guard%20that%20fails%20fast%20in%20this%20case%2C%20e.g.%20a%20job%20with%20condition%20%60github.event_name%20%3D%3D%20'workflow_dispatch'%20%26%26%20inputs.dry_run%20%3D%3D%20false%20%26%26%20inputs.publish_tag%20%3D%3D%20''%60%20that%20runs%20an%20%60echo%60%20%2B%20%60exit%201%60.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fpublish-mcp-server.yml%3A125%0A**%60dry-run%60%20checkout%20behaviour%20change**%0A%0ABefore%20this%20PR%20the%20%60dry-run%60%20job%20always%20checked%20out%20the%20dispatching%20%60github.ref%60.%20Now%20it%20checks%20out%20%60inputs.publish_tag%60%20when%20that%20input%20is%20provided%20%E2%80%94%20even%20though%20the%20job%20description%20only%20mentions%20build%2Ftest%2Ftypecheck%20%28no%20publishing%29.%20A%20user%20who%20supplies%20%60publish_tag%60%20while%20leaving%20%60dry_run%3Dtrue%60%20may%20not%20realise%20they're%20dry-running%20against%20a%20different%20commit%20than%20their%20current%20branch.%20A%20comment%20explaining%20this%20intentional%20behaviour%20would%20help%20future%20readers.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fpublish-mcp-server.yml%3A77%0A**Silent%20no-op%20when%20%60dry_run%3Dfalse%60%20and%20%60publish_tag%60%20is%20empty**%0A%0AIf%20a%20user%20manually%20triggers%20the%20workflow%20with%20%60dry_run%3Dfalse%60%20but%20leaves%20%60publish_tag%60%20empty%2C%20neither%20%60publish-existing-release%60%20%28requires%20%60publish_tag%20!%3D%20''%60%29%20nor%20%60dry-run%60%20%28requires%20%60dry_run%20%3D%3D%20true%60%29%20runs%20%E2%80%94%20the%20dispatch%20silently%20succeeds%20with%20no%20jobs%20executed.%20This%20is%20likely%20surprising%20behaviour.%0A%0AConsider%20adding%20a%20validation%20job%20or%20a%20fallback%20guard%20that%20fails%20fast%20in%20this%20case%2C%20e.g.%20a%20job%20with%20condition%20%60github.event_name%20%3D%3D%20'workflow_dispatch'%20%26%26%20inputs.dry_run%20%3D%3D%20false%20%26%26%20inputs.publish_tag%20%3D%3D%20''%60%20that%20runs%20an%20%60echo%60%20%2B%20%60exit%201%60.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fpublish-mcp-server.yml%3A125%0A**%60dry-run%60%20checkout%20behaviour%20change**%0A%0ABefore%20this%20PR%20the%20%60dry-run%60%20job%20always%20checked%20out%20the%20dispatching%20%60github.ref%60.%20Now%20it%20checks%20out%20%60inputs.publish_tag%60%20when%20that%20input%20is%20provided%20%E2%80%94%20even%20though%20the%20job%20description%20only%20mentions%20build%2Ftest%2Ftypecheck%20%28no%20publishing%29.%20A%20user%20who%20supplies%20%60publish_tag%60%20while%20leaving%20%60dry_run%3Dtrue%60%20may%20not%20realise%20they're%20dry-running%20against%20a%20different%20commit%20than%20their%20current%20branch.%20A%20comment%20explaining%20this%20intentional%20behaviour%20would%20help%20future%20readers.%0A%0A&repo=astandrik%2Flocal-ydb-toolkit&pr=27&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/publish-mcp-server.yml
Line: 77

Comment:
**Silent no-op when `dry_run=false` and `publish_tag` is empty**

If a user manually triggers the workflow with `dry_run=false` but leaves `publish_tag` empty, neither `publish-existing-release` (requires `publish_tag != ''`) nor `dry-run` (requires `dry_run == true`) runs — the dispatch silently succeeds with no jobs executed. This is likely surprising behaviour.

Consider adding a validation job or a fallback guard that fails fast in this case, e.g. a job with condition `github.event_name == 'workflow_dispatch' && inputs.dry_run == false && inputs.publish_tag == ''` that runs an `echo` + `exit 1`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/publish-mcp-server.yml
Line: 125

Comment:
**`dry-run` checkout behaviour change**

Before this PR the `dry-run` job always checked out the dispatching `github.ref`. Now it checks out `inputs.publish_tag` when that input is provided — even though the job description only mentions build/test/typecheck (no publishing). A user who supplies `publish_tag` while leaving `dry_run=true` may not realise they're dry-running against a different commit than their current branch. A comment explaining this intentional behaviour would help future readers.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow publishing existing release t..."](https://github.com/astandrik/local-ydb-toolkit/commit/2893d16cbc99e30a23be559e0c1998ca12cb60c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29893191)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->