### PR TITLE
feat: add local YDB permissions MCP tool

### DIFF
--- a/MCP_TOOL_TEST_SCENARIOS.md
+++ b/MCP_TOOL_TEST_SCENARIOS.md
@@ -183,7 +183,7 @@ Avoid:
 - assuming `latest` is the only safe upgrade target
 - using a short major/minor tag in production-like checks when an exact patch tag is available
 
-## Scenario 1B: Background Image Pull
+## Scenario 1C: Background Image Pull
 
 Goal: start slow registry downloads outside synchronous bootstrap or upgrade calls.
 

--- a/MCP_TOOL_TEST_SCENARIOS.md
+++ b/MCP_TOOL_TEST_SCENARIOS.md
@@ -15,6 +15,7 @@ This document covers all public `local_ydb_*` tools currently registered by the 
 - `local_ydb_status_report`
 - `local_ydb_tenant_check`
 - `local_ydb_scheme`
+- `local_ydb_permissions`
 - `local_ydb_nodes_check`
 - `local_ydb_graphshard_check`
 - `local_ydb_auth_check`
@@ -109,6 +110,7 @@ Calls:
 { "tool": "local_ydb_scheme", "arguments": { "profile": "ghcr261-clean" } }
 { "tool": "local_ydb_scheme", "arguments": { "profile": "ghcr261-clean", "action": "list", "recursive": true, "onePerLine": true } }
 { "tool": "local_ydb_scheme", "arguments": { "profile": "ghcr261-clean", "action": "describe", "path": "/local/example", "stats": true } }
+{ "tool": "local_ydb_permissions", "arguments": { "profile": "ghcr261-clean" } }
 ```
 
 Expected:
@@ -117,6 +119,7 @@ Expected:
 - `storage_leftovers` reports candidate volumes/paths without mutating them.
 - `status_report` returns a structured snapshot even when the stack is not yet healthy.
 - `scheme` defaults to the tenant root, returns `command`, capped `stdout`/`stderr`, original uncapped byte counts, and truncation flags.
+- `permissions` defaults to the tenant root for read-only ACL inspection and returns the owner, direct permissions, and effective permissions from the YDB CLI output.
 - recursive scheme listings should use `maxOutputBytes` when the tenant has many objects.
 
 Avoid:
@@ -124,7 +127,39 @@ Avoid:
 - Treating `status_report.tenant=not-ok` as a transport failure. It often just means the stack is not bootstrapped yet.
 - Passing list-only flags such as `recursive` to `action=describe`, or `stats` to `action=list`.
 
-## Scenario 1A: Published Image Tags
+## Scenario 1A: Schema Permissions
+
+Goal: verify ACL command construction and confirm-gating without accidentally changing an active stack.
+
+Profile:
+`ghcr261-auth`
+
+Calls:
+
+```json
+{ "tool": "local_ydb_permissions", "arguments": { "profile": "ghcr261-auth", "action": "list", "path": "/local/example" } }
+{ "tool": "local_ydb_permissions", "arguments": { "profile": "ghcr261-auth", "action": "grant", "path": "/local/example", "subject": "testuser", "permissions": ["ydb.generic.read"], "confirm": false } }
+{ "tool": "local_ydb_permissions", "arguments": { "profile": "ghcr261-auth", "action": "revoke", "path": "/local/example", "subject": "testuser", "permissions": ["ydb.generic.read"], "confirm": false } }
+{ "tool": "local_ydb_permissions", "arguments": { "profile": "ghcr261-auth", "action": "set", "path": "/local/example", "subject": "testuser", "permissions": ["ydb.generic.read", "ydb.generic.list"], "confirm": false } }
+{ "tool": "local_ydb_permissions", "arguments": { "profile": "ghcr261-auth", "action": "clear", "path": "/local/example", "confirm": false } }
+{ "tool": "local_ydb_permissions", "arguments": { "profile": "ghcr261-auth", "action": "chown", "path": "/local/example", "owner": "root", "confirm": false } }
+{ "tool": "local_ydb_permissions", "arguments": { "profile": "ghcr261-auth", "action": "clear-inheritance", "path": "/local/example", "confirm": false } }
+{ "tool": "local_ydb_permissions", "arguments": { "profile": "ghcr261-auth", "action": "set-inheritance", "path": "/local/example", "confirm": false } }
+```
+
+Expected:
+
+- `action=list` executes without `confirm` and returns capped stdout/stderr plus byte counts.
+- mutating actions return `executed=false`, planned command text, rollback notes, and verification steps when `confirm` is omitted or false.
+- `grant`, `revoke`, and `set` render each permission as a separate `-p` argument.
+- authenticated profiles redact configured password-file paths in planned command text.
+
+Avoid:
+
+- using `confirm: true` for `clear`, `chown`, or inheritance changes unless the target path and rollback are already captured by `action=list`.
+- passing a comma-separated permission string; use the structured `permissions` array.
+
+## Scenario 1B: Published Image Tags
 
 Goal: verify that the registry tag listing tool can discover concrete `local-ydb` image versions before an upgrade.
 
@@ -693,9 +728,9 @@ Avoid:
 - Backup and restore:
   `local_ydb_dump_tenant`, `local_ydb_restore_tenant`
 - Auth rollout:
-  `local_ydb_prepare_auth_config`, `local_ydb_write_dynamic_auth_config`, `local_ydb_apply_auth_hardening`, `local_ydb_set_root_password`, `local_ydb_auth_check`
+  `local_ydb_prepare_auth_config`, `local_ydb_write_dynamic_auth_config`, `local_ydb_apply_auth_hardening`, `local_ydb_set_root_password`, `local_ydb_permissions`, `local_ydb_auth_check`
 - Read-only diagnostics:
-  `local_ydb_inventory`, `local_ydb_database_status`, `local_ydb_container_logs`, `local_ydb_status_report`, `local_ydb_tenant_check`, `local_ydb_scheme`, `local_ydb_nodes_check`, `local_ydb_graphshard_check`, `local_ydb_storage_placement`, `local_ydb_storage_leftovers`
+  `local_ydb_inventory`, `local_ydb_database_status`, `local_ydb_container_logs`, `local_ydb_status_report`, `local_ydb_tenant_check`, `local_ydb_scheme`, `local_ydb_permissions`, `local_ydb_nodes_check`, `local_ydb_graphshard_check`, `local_ydb_storage_placement`, `local_ydb_storage_leftovers`
 - Cleanup:
   `local_ydb_cleanup_storage`
 

--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ SSH profiles use existing SSH agent/key/known_hosts configuration. The toolkit d
 
 ### Operations
 
-Read-only tools collect inventory, tenant state, schema objects, node state, GraphShard state, auth posture, storage placement, leftover storage candidates, published `local-ydb` image tags, and background image-pull status.
+Read-only tools collect inventory, tenant state, schema objects, schema permissions, node state, GraphShard state, auth posture, storage placement, leftover storage candidates, published `local-ydb` image tags, and background image-pull status.
 
 `local_ydb_check_prerequisites` is the expected first step on a new host or profile. It checks `docker`, `curl`, `ruby`, and auth-file prerequisites. With `confirm: true`, it can auto-install supported host helpers such as `curl` and `ruby` through `apt-get`; Docker is reported but must still be installed manually.
 
-Mutating tools include image pulls, bootstrap, tenant creation, dynamic-node startup, restart, dump, restore, auth config application, root-password rotation, storage-pool reduction by rebuild, version upgrade by dump/rebuild/restore, and explicit storage cleanup. They are plan-only unless called with:
+Mutating tools include image pulls, bootstrap, tenant creation, dynamic-node startup, restart, schema permissions changes, dump, restore, auth config application, root-password rotation, storage-pool reduction by rebuild, version upgrade by dump/rebuild/restore, and explicit storage cleanup. They are plan-only unless called with:
 
 ```json
 {
@@ -151,6 +151,8 @@ Without `confirm: true`, mutating tools return planned commands, risk, rollback 
 `local_ydb_list_versions` lists registry tags for a `local-ydb` image such as `ghcr.io/ydb-platform/local-ydb`. It follows OCI/Docker Registry V2 pagination and bearer-token challenges, then returns numeric version tags newest first so the MCP client can discover concrete tags before changing a profile version.
 
 `local_ydb_scheme` lists or describes schema objects with the YDB CLI. It defaults to `scheme ls` at the configured tenant root, supports `recursive`, `long`, and `onePerLine` list options, and supports `stats` for `scheme describe`. Large stdout/stderr streams are capped per stream and returned with original uncapped byte counts and truncation flags so MCP responses stay usable.
+
+`local_ydb_permissions` manages YDB schema ACLs through `scheme permissions`. Its read-only `list` action defaults to the configured tenant root and runs without `confirm`. Mutating actions `grant`, `revoke`, `set`, `clear`, `chown`, `set-inheritance`, and `clear-inheritance` return a plan unless `confirm: true` is supplied. For `grant`, `revoke`, and `set`, pass permission names as a structured `permissions` array; each item is emitted as a separate `-p` CLI argument.
 
 `local_ydb_pull_image` starts a background `docker pull` for a profile image or explicit image and returns a `jobId` immediately. Poll `local_ydb_pull_status` with that `jobId` until it reaches `completed` before retrying bootstrap or upgrade. This keeps slow registry downloads out of synchronous bootstrap/upgrade tool calls.
 

--- a/packages/core/src/operations.ts
+++ b/packages/core/src/operations.ts
@@ -10,3 +10,4 @@ export * from "./operations/auth-operations.js";
 export * from "./operations/prerequisites.js";
 export * from "./operations/version.js";
 export * from "./operations/scheme.js";
+export * from "./operations/permissions.js";

--- a/packages/core/src/operations/output.ts
+++ b/packages/core/src/operations/output.ts
@@ -1,0 +1,41 @@
+import { Buffer } from "node:buffer";
+
+export const DEFAULT_MAX_OUTPUT_BYTES = 65_536;
+export const MAX_OUTPUT_BYTES_LIMIT = 1_048_576;
+
+export interface CappedText {
+  text: string;
+  bytes: number;
+  truncated: boolean;
+}
+
+export function normalizeMaxOutputBytes(value: number | undefined): number {
+  const maxOutputBytes = value ?? DEFAULT_MAX_OUTPUT_BYTES;
+  if (!Number.isInteger(maxOutputBytes) || maxOutputBytes <= 0) {
+    throw new Error("maxOutputBytes must be a positive integer");
+  }
+  if (maxOutputBytes > MAX_OUTPUT_BYTES_LIMIT) {
+    throw new Error(`maxOutputBytes must be ${MAX_OUTPUT_BYTES_LIMIT} or less`);
+  }
+  return maxOutputBytes;
+}
+
+export function capText(input: string, maxBytes: number): CappedText {
+  const bytes = Buffer.byteLength(input, "utf8");
+  if (bytes <= maxBytes) {
+    return { text: input, bytes, truncated: false };
+  }
+
+  let usedBytes = 0;
+  const parts: string[] = [];
+  for (const char of input) {
+    const charBytes = Buffer.byteLength(char, "utf8");
+    if (usedBytes + charBytes > maxBytes) {
+      break;
+    }
+    parts.push(char);
+    usedBytes += charBytes;
+  }
+
+  return { text: parts.join(""), bytes, truncated: true };
+}

--- a/packages/core/src/operations/permissions.ts
+++ b/packages/core/src/operations/permissions.ts
@@ -1,0 +1,237 @@
+import { ydbCli } from "./commands.js";
+import { runMutating } from "./execution.js";
+import { capText, normalizeMaxOutputBytes } from "./output.js";
+import type {
+  OperationPlan,
+  PermissionsAction,
+  PermissionsMutationResponse,
+  PermissionsOptions,
+  PermissionsResponse,
+  ToolkitContext,
+} from "./types.js";
+
+type MutatingPermissionsAction = Exclude<PermissionsAction, "list">;
+
+export async function managePermissions(
+  ctx: ToolkitContext,
+  options: PermissionsOptions = {},
+): Promise<PermissionsResponse> {
+  const action = options.action ?? "list";
+  validateAction(action);
+
+  const path = normalizeNonEmpty("path", options.path ?? ctx.profile.tenantPath);
+  const args = permissionsArgs(action, path, options);
+
+  if (action === "list") {
+    const maxOutputBytes = normalizeMaxOutputBytes(options.maxOutputBytes);
+    const result = await ctx.client.run(ydbCli(
+      ctx.profile,
+      args,
+      ctx.profile.tenantPath,
+      "List YDB scheme permissions",
+    ));
+    const stdout = capText(result.stdout, maxOutputBytes);
+    const stderr = capText(result.stderr, maxOutputBytes);
+
+    return {
+      summary: permissionsListSummary(path, result.ok, stdout.truncated || stderr.truncated),
+      ok: result.ok,
+      action,
+      path,
+      command: result.command,
+      stdout: stdout.text,
+      stderr: stderr.text,
+      stdoutBytes: stdout.bytes,
+      stderrBytes: stderr.bytes,
+      stdoutTruncated: stdout.truncated,
+      stderrTruncated: stderr.truncated,
+      maxOutputBytes,
+    };
+  }
+
+  const normalized = normalizedMutationFields(action, options);
+  const response = await runMutating(ctx, {
+    summary: permissionsMutationSummary(action, path, normalized),
+    risk: permissionsRisk(action),
+    specs: [
+      ydbCli(
+        ctx.profile,
+        args,
+        ctx.profile.tenantPath,
+        permissionsDescription(action),
+      ),
+    ],
+    rollback: permissionsRollback(action, normalized),
+    verification: [
+      `Run local_ydb_permissions with action=list and path=${path} to inspect direct and effective permissions.`,
+    ],
+  }, options);
+
+  return {
+    ...response,
+    action,
+    path,
+    ...normalized,
+  };
+}
+
+function permissionsArgs(
+  action: PermissionsAction,
+  path: string,
+  options: PermissionsOptions,
+): string[] {
+  if (action === "list") {
+    ensureNoMutationOnlyFields(action, options);
+    return ["scheme", "permissions", "list", path];
+  }
+
+  if (action === "grant" || action === "revoke" || action === "set") {
+    const subject = normalizeNonEmpty("subject", options.subject);
+    const permissions = normalizePermissions(action, options.permissions);
+    return [
+      "scheme",
+      "permissions",
+      action,
+      ...permissions.flatMap((permission) => ["-p", permission]),
+      path,
+      subject,
+    ];
+  }
+
+  if (action === "chown") {
+    return [
+      "scheme",
+      "permissions",
+      "chown",
+      path,
+      normalizeNonEmpty("owner", options.owner),
+    ];
+  }
+
+  ensureNoMutationOnlyFields(action, options);
+  return ["scheme", "permissions", action, path];
+}
+
+function normalizedMutationFields(
+  action: MutatingPermissionsAction,
+  options: PermissionsOptions,
+): Omit<PermissionsMutationResponse, keyof OperationPlan | "summary" | "executed" | "results" | "action" | "path"> {
+  if (action === "grant" || action === "revoke" || action === "set") {
+    return {
+      subject: normalizeNonEmpty("subject", options.subject),
+      permissions: normalizePermissions(action, options.permissions),
+    };
+  }
+  if (action === "chown") {
+    return { owner: normalizeNonEmpty("owner", options.owner) };
+  }
+  return {};
+}
+
+function normalizePermissions(action: "grant" | "revoke" | "set", values: string[] | undefined): string[] {
+  const permissions = (values ?? []).map((value, index) =>
+    normalizeNonEmpty(`permissions[${index}]`, value));
+  if (permissions.length === 0) {
+    throw new Error(`At least one permission to ${action} should be provided`);
+  }
+  return permissions;
+}
+
+function normalizeNonEmpty(name: string, value: string | undefined): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new Error(`${name} must be non-empty`);
+  }
+  return normalized;
+}
+
+function ensureNoMutationOnlyFields(action: PermissionsAction, options: PermissionsOptions): void {
+  if (options.subject !== undefined) {
+    throw new Error(`subject is not supported when action is ${action}`);
+  }
+  if (options.owner !== undefined) {
+    throw new Error(`owner is not supported when action is ${action}`);
+  }
+  if (options.permissions !== undefined) {
+    throw new Error(`permissions is not supported when action is ${action}`);
+  }
+}
+
+function validateAction(action: string): asserts action is PermissionsAction {
+  if (![
+    "list",
+    "grant",
+    "revoke",
+    "set",
+    "clear",
+    "chown",
+    "set-inheritance",
+    "clear-inheritance",
+  ].includes(action)) {
+    throw new Error(`Unsupported permissions action: ${action}`);
+  }
+}
+
+function permissionsRisk(action: MutatingPermissionsAction): OperationPlan["risk"] {
+  return action === "grant" || action === "revoke" ? "medium" : "high";
+}
+
+function permissionsDescription(action: MutatingPermissionsAction): string {
+  switch (action) {
+    case "grant":
+      return "Grant YDB scheme permissions";
+    case "revoke":
+      return "Revoke YDB scheme permissions";
+    case "set":
+      return "Set YDB scheme permissions";
+    case "clear":
+      return "Clear direct YDB scheme permissions";
+    case "chown":
+      return "Change YDB scheme owner";
+    case "set-inheritance":
+      return "Enable YDB scheme permission inheritance";
+    case "clear-inheritance":
+      return "Disable YDB scheme permission inheritance";
+  }
+}
+
+function permissionsMutationSummary(
+  action: MutatingPermissionsAction,
+  path: string,
+  fields: Pick<PermissionsMutationResponse, "subject" | "permissions" | "owner">,
+): string {
+  if (action === "grant" || action === "revoke" || action === "set") {
+    return `${permissionsDescription(action)} at ${path} for ${fields.subject}.`;
+  }
+  if (action === "chown") {
+    return `${permissionsDescription(action)} at ${path} to ${fields.owner}.`;
+  }
+  return `${permissionsDescription(action)} at ${path}.`;
+}
+
+function permissionsRollback(
+  action: MutatingPermissionsAction,
+  fields: Pick<PermissionsMutationResponse, "subject" | "permissions" | "owner">,
+): string[] {
+  if (action === "grant") {
+    return [`Run action=revoke for subject=${fields.subject} with the same permissions if the grant should be undone.`];
+  }
+  if (action === "revoke") {
+    return [`Run action=grant for subject=${fields.subject} with the same permissions if the revoke should be undone.`];
+  }
+  if (action === "set" || action === "clear") {
+    return ["Restore the previous direct permissions from a prior action=list capture."];
+  }
+  if (action === "chown") {
+    return ["Run action=chown with the previous owner from a prior action=list capture."];
+  }
+  if (action === "set-inheritance") {
+    return ["Run action=clear-inheritance to disable inherited permissions again."];
+  }
+  return ["Run action=set-inheritance to enable inherited permissions again."];
+}
+
+function permissionsListSummary(path: string, ok: boolean, truncated: boolean): string {
+  const status = ok ? "succeeded" : "failed";
+  return `List permissions at ${path} ${status}${truncated ? " with capped output" : ""}.`;
+}

--- a/packages/core/src/operations/permissions.ts
+++ b/packages/core/src/operations/permissions.ts
@@ -99,6 +99,7 @@ function permissionsArgs(
   }
 
   if (action === "chown") {
+    ensureNoMutationOnlyFields(action, { ...options, owner: undefined });
     return [
       "scheme",
       "permissions",

--- a/packages/core/src/operations/permissions.ts
+++ b/packages/core/src/operations/permissions.ts
@@ -86,6 +86,9 @@ function permissionsArgs(
   }
 
   if (action === "grant" || action === "revoke" || action === "set") {
+    if (options.owner !== undefined) {
+      throw new Error(`owner is not supported when action is ${action}`);
+    }
     const subject = normalizeNonEmpty("subject", options.subject);
     const permissions = normalizePermissions(action, options.permissions);
     return [

--- a/packages/core/src/operations/scheme.ts
+++ b/packages/core/src/operations/scheme.ts
@@ -1,15 +1,6 @@
-import { Buffer } from "node:buffer";
 import { ydbCli } from "./commands.js";
+import { capText, normalizeMaxOutputBytes } from "./output.js";
 import type { SchemeAction, SchemeOptions, SchemeResponse, ToolkitContext } from "./types.js";
-
-const DEFAULT_MAX_OUTPUT_BYTES = 65_536;
-const MAX_OUTPUT_BYTES_LIMIT = 1_048_576;
-
-interface CappedText {
-  text: string;
-  bytes: number;
-  truncated: boolean;
-}
 
 export async function inspectScheme(
   ctx: ToolkitContext,
@@ -75,37 +66,6 @@ function schemeArgs(action: SchemeAction, path: string, options: SchemeOptions):
     path,
     ...(options.stats ? ["--stats"] : [])
   ];
-}
-
-function normalizeMaxOutputBytes(value: number | undefined): number {
-  const maxOutputBytes = value ?? DEFAULT_MAX_OUTPUT_BYTES;
-  if (!Number.isInteger(maxOutputBytes) || maxOutputBytes <= 0) {
-    throw new Error("maxOutputBytes must be a positive integer");
-  }
-  if (maxOutputBytes > MAX_OUTPUT_BYTES_LIMIT) {
-    throw new Error(`maxOutputBytes must be ${MAX_OUTPUT_BYTES_LIMIT} or less`);
-  }
-  return maxOutputBytes;
-}
-
-function capText(input: string, maxBytes: number): CappedText {
-  const bytes = Buffer.byteLength(input, "utf8");
-  if (bytes <= maxBytes) {
-    return { text: input, bytes, truncated: false };
-  }
-
-  let usedBytes = 0;
-  const parts: string[] = [];
-  for (const char of input) {
-    const charBytes = Buffer.byteLength(char, "utf8");
-    if (usedBytes + charBytes > maxBytes) {
-      break;
-    }
-    parts.push(char);
-    usedBytes += charBytes;
-  }
-
-  return { text: parts.join(""), bytes, truncated: true };
 }
 
 function schemeSummary(action: SchemeAction, path: string, ok: boolean, truncated: boolean): string {

--- a/packages/core/src/operations/types.ts
+++ b/packages/core/src/operations/types.ts
@@ -85,6 +85,25 @@ export interface SchemeOptions {
   maxOutputBytes?: number;
 }
 
+export type PermissionsAction =
+  | "list"
+  | "grant"
+  | "revoke"
+  | "set"
+  | "clear"
+  | "chown"
+  | "set-inheritance"
+  | "clear-inheritance";
+
+export interface PermissionsOptions extends MutatingOptions {
+  action?: PermissionsAction;
+  path?: string;
+  subject?: string;
+  permissions?: string[];
+  owner?: string;
+  maxOutputBytes?: number;
+}
+
 export interface SetRootPasswordOptions extends MutatingOptions {
   password?: string;
 }
@@ -257,3 +276,35 @@ export interface SchemeResponse {
   /** Maximum bytes returned in each stdout/stderr field. */
   maxOutputBytes: number;
 }
+
+export interface PermissionsListResponse {
+  summary: string;
+  ok: boolean;
+  action: "list";
+  path: string;
+  command: string;
+  /** Captured stdout, potentially capped to maxOutputBytes. */
+  stdout: string;
+  /** Captured stderr, potentially capped to maxOutputBytes. */
+  stderr: string;
+  /** Byte length of the original uncapped stdout stream. */
+  stdoutBytes: number;
+  /** Byte length of the original uncapped stderr stream. */
+  stderrBytes: number;
+  /** Whether stdout was truncated due to maxOutputBytes. */
+  stdoutTruncated: boolean;
+  /** Whether stderr was truncated due to maxOutputBytes. */
+  stderrTruncated: boolean;
+  /** Maximum bytes returned in each stdout/stderr field. */
+  maxOutputBytes: number;
+}
+
+export interface PermissionsMutationResponse extends OperationResponse {
+  action: Exclude<PermissionsAction, "list">;
+  path: string;
+  subject?: string;
+  permissions?: string[];
+  owner?: string;
+}
+
+export type PermissionsResponse = PermissionsListResponse | PermissionsMutationResponse;

--- a/packages/core/test/permissions.test.ts
+++ b/packages/core/test/permissions.test.ts
@@ -181,6 +181,13 @@ describe("permissions management", () => {
     })).rejects.toThrow(/At least one permission/);
 
     await expect(managePermissions(ctx, {
+      action: "grant",
+      subject: "testuser",
+      permissions: ["ydb.generic.read"],
+      owner: "new-owner",
+    })).rejects.toThrow(/owner is not supported/);
+
+    await expect(managePermissions(ctx, {
       action: "chown",
     })).rejects.toThrow(/owner must be non-empty/);
 

--- a/packages/core/test/permissions.test.ts
+++ b/packages/core/test/permissions.test.ts
@@ -184,6 +184,12 @@ describe("permissions management", () => {
       action: "chown",
     })).rejects.toThrow(/owner must be non-empty/);
 
+    await expect(managePermissions(ctx, {
+      action: "chown",
+      owner: "new-owner",
+      subject: "testuser",
+    })).rejects.toThrow(/subject is not supported/);
+
     expect(executor.commands).toEqual([]);
   });
 

--- a/packages/core/test/permissions.test.ts
+++ b/packages/core/test/permissions.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  commandToShell,
+  createContext,
+  managePermissions,
+  ShellCommandExecutor,
+  type CommandExecutor,
+  type CommandResult,
+  type CommandSpec,
+  type PermissionsListResponse,
+  type PermissionsMutationResponse,
+  type PermissionsResponse,
+  type ResolvedLocalYdbProfile,
+} from "../src/index.js";
+import { ConfigSchema } from "../src/validation.js";
+
+class RecordingExecutor implements CommandExecutor {
+  readonly commands: string[] = [];
+
+  constructor(
+    readonly stdout = "",
+    readonly stderr = "",
+    readonly ok = true,
+  ) {}
+
+  display(_profile: ResolvedLocalYdbProfile, spec: CommandSpec): string {
+    return commandToShell(spec);
+  }
+
+  async run(profile: ResolvedLocalYdbProfile, spec: CommandSpec): Promise<CommandResult> {
+    const command = this.display(profile, spec);
+    this.commands.push(command);
+    return {
+      command,
+      exitCode: this.ok ? 0 : 1,
+      stdout: this.stdout,
+      stderr: this.stderr,
+      ok: this.ok,
+      timedOut: false,
+    };
+  }
+}
+
+class DisplayOnlyShellExecutor extends ShellCommandExecutor {
+  readonly commands: string[] = [];
+
+  async run(profile: ResolvedLocalYdbProfile, spec: CommandSpec): Promise<CommandResult> {
+    const command = this.display(profile, spec);
+    this.commands.push(command);
+    return {
+      command,
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      ok: true,
+      timedOut: false,
+    };
+  }
+}
+
+function expectMutationResponse(response: PermissionsResponse): PermissionsMutationResponse {
+  if (!("plannedCommands" in response)) {
+    throw new Error("Expected a mutating permissions response");
+  }
+  return response;
+}
+
+function expectListResponse(response: PermissionsResponse): PermissionsListResponse {
+  if (response.action !== "list") {
+    throw new Error("Expected a permissions list response");
+  }
+  return response;
+}
+
+describe("permissions management", () => {
+  it("lists permissions for the configured tenant root without confirm", async () => {
+    const executor = new RecordingExecutor("Owner: root\n");
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+
+    const response = expectListResponse(await managePermissions(ctx));
+
+    expect(response).toMatchObject({
+      ok: true,
+      action: "list",
+      path: "/local/example",
+      stdout: "Owner: root\n",
+      stdoutTruncated: false,
+      stderrTruncated: false,
+      maxOutputBytes: 65_536,
+    });
+    expect(response.command).toContain("scheme permissions list /local/example");
+    expect(response.command).toContain("-d /local/example");
+    expect(executor.commands).toHaveLength(1);
+  });
+
+  it("passes each granted permission as a separate CLI argument", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+
+    const response = expectMutationResponse(await managePermissions(ctx, {
+      action: "grant",
+      path: "/local/example/app",
+      subject: "testuser",
+      permissions: ["ydb.generic.read", "ydb.access.grant"],
+    }));
+
+    expect(response).toMatchObject({
+      executed: false,
+      action: "grant",
+      path: "/local/example/app",
+      subject: "testuser",
+      permissions: ["ydb.generic.read", "ydb.access.grant"],
+    });
+    expect(executor.commands).toEqual([]);
+    expect(response.plannedCommands[0]).toContain(
+      "scheme permissions grant -p ydb.generic.read -p ydb.access.grant /local/example/app testuser",
+    );
+  });
+
+  it("executes mutating permission actions only with confirm=true", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+
+    const response = expectMutationResponse(await managePermissions(ctx, {
+      action: "revoke",
+      path: "/local/example/app",
+      subject: "testuser",
+      permissions: ["ydb.generic.read"],
+      confirm: true,
+    }));
+
+    expect(response.executed).toBe(true);
+    expect(response.results).toHaveLength(1);
+    expect(executor.commands).toEqual(response.plannedCommands);
+    expect(executor.commands[0]).toContain(
+      "scheme permissions revoke -p ydb.generic.read /local/example/app testuser",
+    );
+  });
+
+  it("builds clear, chown, and inheritance commands in upstream CLI shape", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+
+    const clear = expectMutationResponse(await managePermissions(ctx, {
+      action: "clear",
+      path: "/local/example/app",
+    }));
+    const chown = expectMutationResponse(await managePermissions(ctx, {
+      action: "chown",
+      path: "/local/example/app",
+      owner: "new-owner",
+    }));
+    const setInheritance = expectMutationResponse(await managePermissions(ctx, {
+      action: "set-inheritance",
+      path: "/local/example/app",
+    }));
+    const clearInheritance = expectMutationResponse(await managePermissions(ctx, {
+      action: "clear-inheritance",
+      path: "/local/example/app",
+    }));
+
+    expect(clear.plannedCommands[0]).toContain("scheme permissions clear /local/example/app");
+    expect(chown.plannedCommands[0]).toContain("scheme permissions chown /local/example/app new-owner");
+    expect(setInheritance.plannedCommands[0]).toContain("scheme permissions set-inheritance /local/example/app");
+    expect(clearInheritance.plannedCommands[0]).toContain("scheme permissions clear-inheritance /local/example/app");
+    expect(executor.commands).toEqual([]);
+  });
+
+  it("rejects missing subject, owner, and permissions before command execution", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+
+    await expect(managePermissions(ctx, {
+      action: "grant",
+      permissions: ["ydb.generic.read"],
+    })).rejects.toThrow(/subject must be non-empty/);
+
+    await expect(managePermissions(ctx, {
+      action: "grant",
+      subject: "testuser",
+    })).rejects.toThrow(/At least one permission/);
+
+    await expect(managePermissions(ctx, {
+      action: "chown",
+    })).rejects.toThrow(/owner must be non-empty/);
+
+    expect(executor.commands).toEqual([]);
+  });
+
+  it("redacts root password file paths in authenticated command text", async () => {
+    const executor = new DisplayOnlyShellExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({
+      profiles: {
+        default: {
+          rootPasswordFile: "/tmp/local-ydb/root.password",
+        },
+      },
+    }));
+
+    const response = expectMutationResponse(await managePermissions(ctx, {
+      action: "grant",
+      subject: "testuser",
+      permissions: ["ydb.generic.read"],
+    }));
+
+    expect(response.plannedCommands[0]).toContain("<redacted>");
+    expect(response.plannedCommands[0]).not.toContain("/tmp/local-ydb/root.password");
+  });
+});

--- a/packages/mcp-server/src/tools/args.ts
+++ b/packages/mcp-server/src/tools/args.ts
@@ -20,6 +20,25 @@ export const SchemeArgs = ProfileArgs.extend({
   maxOutputBytes: z.number().int().positive().max(1_048_576).optional(),
 });
 
+export const PermissionsArgs = ProfileArgs.extend({
+  action: z.enum([
+    "list",
+    "grant",
+    "revoke",
+    "set",
+    "clear",
+    "chown",
+    "set-inheritance",
+    "clear-inheritance",
+  ]).optional(),
+  path: z.string().min(1).optional(),
+  subject: z.string().min(1).optional(),
+  permissions: z.array(z.string().min(1)).nonempty().optional(),
+  owner: z.string().min(1).optional(),
+  maxOutputBytes: z.number().int().positive().max(1_048_576).optional(),
+  confirm: z.boolean().optional(),
+});
+
 export const MutatingArgs = ProfileArgs.extend({
   confirm: z.boolean().optional(),
 });

--- a/packages/mcp-server/src/tools/input-schemas.ts
+++ b/packages/mcp-server/src/tools/input-schemas.ts
@@ -89,6 +89,73 @@ export function schemeSchema(): Tool["inputSchema"] {
   };
 }
 
+export function permissionsSchema(): Tool["inputSchema"] {
+  return {
+    type: "object",
+    properties: {
+      profile: {
+        type: "string",
+        description:
+          "Named profile from local-ydb.config.json. Defaults to config.defaultProfile.",
+      },
+      configPath: {
+        type: "string",
+        description:
+          "Explicit local-ydb config file path to load for this tool call.",
+      },
+      action: {
+        type: "string",
+        enum: [
+          "list",
+          "grant",
+          "revoke",
+          "set",
+          "clear",
+          "chown",
+          "set-inheritance",
+          "clear-inheritance",
+        ],
+        description:
+          "Permissions operation to run. Defaults to list, which is read-only and does not require confirm.",
+      },
+      path: {
+        type: "string",
+        description:
+          "Scheme path to manage. Defaults to the configured tenant root.",
+      },
+      subject: {
+        type: "string",
+        description:
+          "User or group subject for grant, revoke, and set actions.",
+      },
+      permissions: {
+        type: "array",
+        minItems: 1,
+        items: { type: "string", minLength: 1 },
+        description:
+          "Permission names for grant, revoke, and set actions. Each item is passed as its own -p argument.",
+      },
+      owner: {
+        type: "string",
+        description: "New owner for action=chown.",
+      },
+      maxOutputBytes: {
+        type: "integer",
+        minimum: 1,
+        maximum: 1_048_576,
+        description:
+          "For action=list, maximum UTF-8 bytes returned per stdout/stderr stream. Defaults to 65536.",
+      },
+      confirm: {
+        type: "boolean",
+        description:
+          "Must be true to execute mutating actions. Omit or false for plan-only output. Not required for action=list.",
+      },
+    },
+    additionalProperties: false,
+  };
+}
+
 export function listVersionsSchema(): Tool["inputSchema"] {
   return {
     type: "object",

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -15,6 +15,7 @@ import {
   inspectScheme,
   inventory,
   listVersions,
+  managePermissions,
   nodesCheck,
   prepareAuthConfig,
   pullImage,
@@ -46,6 +47,7 @@ import {
   ListVersionsArgs,
   LogsArgs,
   MutatingArgs,
+  PermissionsArgs,
   PrepareAuthConfigArgs,
   ProfileArgs,
   PullImageArgs,
@@ -68,6 +70,7 @@ import {
   listVersionsSchema,
   logsSchema,
   mutatingSchema,
+  permissionsSchema,
   prepareAuthConfigSchema,
   profileSchema,
   pullImageSchema,
@@ -173,6 +176,16 @@ export const toolDefinitions = [
     inputSchema: schemeSchema(),
     handler: withContext(SchemeArgs, (context, parsed) =>
       inspectScheme(context, parsed),
+    ),
+  }),
+  defineTool({
+    group: "auth",
+    name: "local_ydb_permissions",
+    description:
+      "List, grant, revoke, set, clear, chown, or toggle inheritance for YDB scheme permissions.",
+    inputSchema: permissionsSchema(),
+    handler: withContext(PermissionsArgs, (context, parsed) =>
+      managePermissions(context, parsed),
     ),
   }),
   defineTool({

--- a/packages/mcp-server/test/tools.test.ts
+++ b/packages/mcp-server/test/tools.test.ts
@@ -64,6 +64,7 @@ describe("mcp tools", () => {
       "local_ydb_inventory",
       "local_ydb_list_versions",
       "local_ydb_nodes_check",
+      "local_ydb_permissions",
       "local_ydb_prepare_auth_config",
       "local_ydb_pull_image",
       "local_ydb_pull_status",
@@ -212,6 +213,30 @@ describe("mcp tools", () => {
     });
   });
 
+  it("exposes permissions management options in the tool schema", () => {
+    const tool = localYdbTools.find((candidate) => candidate.name === "local_ydb_permissions");
+    expect(tool?.inputSchema.properties?.action).toMatchObject({
+      type: "string",
+      enum: [
+        "list",
+        "grant",
+        "revoke",
+        "set",
+        "clear",
+        "chown",
+        "set-inheritance",
+        "clear-inheritance"
+      ]
+    });
+    expect(tool?.inputSchema.properties?.permissions).toMatchObject({
+      type: "array",
+      minItems: 1
+    });
+    expect(tool?.inputSchema.properties?.subject).toMatchObject({ type: "string" });
+    expect(tool?.inputSchema.properties?.owner).toMatchObject({ type: "string" });
+    expect(tool?.inputSchema.properties?.confirm).toMatchObject({ type: "boolean" });
+  });
+
   it("requires version for the upgrade tool schema", () => {
     const tool = localYdbTools.find((candidate) => candidate.name === "local_ydb_upgrade_version");
     expect(tool?.inputSchema.required).toContain("version");
@@ -295,6 +320,38 @@ describe("mcp tools", () => {
     expect(result.action).toBe("describe");
     expect(result.path).toBe("/local/example/users");
     expect(result.command).toContain("scheme describe /local/example/users --stats");
+  });
+
+  it("can list permissions through the MCP handler without confirm", async () => {
+    const result = await callLocalYdbToolForTest("local_ydb_permissions", {
+      path: "/local/example/dir"
+    }, {
+      config: ConfigSchema.parse({}),
+      executor: new RecordingExecutor()
+    }) as { action: string; path: string; command: string; maxOutputBytes: number };
+
+    expect(result.action).toBe("list");
+    expect(result.path).toBe("/local/example/dir");
+    expect(result.maxOutputBytes).toBe(65_536);
+    expect(result.command).toContain("scheme permissions list /local/example/dir");
+  });
+
+  it("plans mutating permissions through the MCP handler without confirm", async () => {
+    const result = await callLocalYdbToolForTest("local_ydb_permissions", {
+      action: "grant",
+      path: "/local/example/dir",
+      subject: "testuser",
+      permissions: ["ydb.generic.read", "ydb.access.grant"]
+    }, {
+      config: ConfigSchema.parse({}),
+      executor: new RecordingExecutor()
+    }) as { executed: boolean; plannedCommands: string[]; permissions: string[] };
+
+    expect(result.executed).toBe(false);
+    expect(result.permissions).toEqual(["ydb.generic.read", "ydb.access.grant"]);
+    expect(result.plannedCommands[0]).toContain(
+      "scheme permissions grant -p ydb.generic.read -p ydb.access.grant /local/example/dir testuser"
+    );
   });
 
   it("exposes server instructions during initialization", () => {

--- a/skills/local-ydb/references/mcp-tool-scenarios.md
+++ b/skills/local-ydb/references/mcp-tool-scenarios.md
@@ -14,6 +14,8 @@ This document covers all public `local_ydb_*` tools currently registered by the 
 - `local_ydb_destroy_stack`
 - `local_ydb_status_report`
 - `local_ydb_tenant_check`
+- `local_ydb_scheme`
+- `local_ydb_permissions`
 - `local_ydb_nodes_check`
 - `local_ydb_graphshard_check`
 - `local_ydb_auth_check`
@@ -105,6 +107,8 @@ Calls:
 { "tool": "local_ydb_inventory", "arguments": { "profile": "ghcr261-clean" } }
 { "tool": "local_ydb_storage_leftovers", "arguments": { "profile": "ghcr261-clean" } }
 { "tool": "local_ydb_status_report", "arguments": { "profile": "ghcr261-clean" } }
+{ "tool": "local_ydb_scheme", "arguments": { "profile": "ghcr261-clean" } }
+{ "tool": "local_ydb_permissions", "arguments": { "profile": "ghcr261-clean" } }
 ```
 
 Expected:
@@ -112,6 +116,7 @@ Expected:
 - `inventory` returns the profile shape and current container list.
 - `storage_leftovers` reports candidate volumes/paths without mutating them.
 - `status_report` returns a structured snapshot even when the stack is not yet healthy.
+- `scheme` and `permissions` default to the tenant root for read-only schema and ACL inspection.
 
 Avoid:
 
@@ -684,9 +689,9 @@ Avoid:
 - Backup and restore:
   `local_ydb_dump_tenant`, `local_ydb_restore_tenant`
 - Auth rollout:
-  `local_ydb_prepare_auth_config`, `local_ydb_write_dynamic_auth_config`, `local_ydb_apply_auth_hardening`, `local_ydb_set_root_password`, `local_ydb_auth_check`
+  `local_ydb_prepare_auth_config`, `local_ydb_write_dynamic_auth_config`, `local_ydb_apply_auth_hardening`, `local_ydb_set_root_password`, `local_ydb_permissions`, `local_ydb_auth_check`
 - Read-only diagnostics:
-  `local_ydb_inventory`, `local_ydb_database_status`, `local_ydb_container_logs`, `local_ydb_status_report`, `local_ydb_tenant_check`, `local_ydb_nodes_check`, `local_ydb_graphshard_check`, `local_ydb_storage_placement`, `local_ydb_storage_leftovers`
+  `local_ydb_inventory`, `local_ydb_database_status`, `local_ydb_container_logs`, `local_ydb_status_report`, `local_ydb_tenant_check`, `local_ydb_scheme`, `local_ydb_permissions`, `local_ydb_nodes_check`, `local_ydb_graphshard_check`, `local_ydb_storage_placement`, `local_ydb_storage_leftovers`
 - Cleanup:
   `local_ydb_cleanup_storage`
 


### PR DESCRIPTION
Closes https://github.com/astandrik/local-ydb-toolkit/issues/20

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the `local_ydb_permissions` MCP tool, which wraps all eight `ydb scheme permissions` sub-commands (`list`, `grant`, `revoke`, `set`, `clear`, `chown`, `set-inheritance`, `clear-inheritance`) behind the existing confirm-gating pattern. It also extracts the shared `capText`/`normalizeMaxOutputBytes` utilities from `scheme.ts` into a new `output.ts` module consumed by both `scheme.ts` and the new `permissions.ts`. The implementation is well-validated, the test coverage is comprehensive, and the field-exclusion logic for `chown` is correctly handled.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no bugs found; only two minor style observations.

All findings are P2 style suggestions (redundant validation pass and lack of a JSON Schema required array). No P0 or P1 defects were identified. The core logic, CLI argument construction, confirm-gating, output capping, and test coverage are all correct.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/operations/permissions.ts | New `managePermissions` function dispatches all eight `scheme permissions` sub-commands with correct validation, confirm-gating, and output-capping; `chown` correctly excludes `owner` from `ensureNoMutationOnlyFields`. Minor: validation of `subject`/`permissions` is run twice for mutating actions. |
| packages/core/src/operations/output.ts | Clean extraction of `capText` and `normalizeMaxOutputBytes` from `scheme.ts` into a shared utility module, now consumed by both `scheme.ts` and `permissions.ts`. |
| packages/core/src/operations/types.ts | Adds `PermissionsAction`, `PermissionsOptions`, `PermissionsListResponse`, `PermissionsMutationResponse`, and `PermissionsResponse` union type; well-aligned with the implementation. |
| packages/mcp-server/src/tools/input-schemas.ts | Adds `permissionsSchema()` with correct enum, array constraints, and `additionalProperties: false`; no `required` array means action-dependent required fields are not validated at the JSON Schema layer. |
| packages/mcp-server/src/tools/args.ts | Adds `PermissionsArgs` Zod schema, consistent with the JSON schema and core types. |
| packages/mcp-server/src/tools/registry.ts | Registers `local_ydb_permissions` in the `"auth"` group with correct handler wiring; no issues found. |
| packages/core/test/permissions.test.ts | Comprehensive test coverage: list, grant/revoke/set CLI shape, confirm-gating, validation rejection, and password-file redaction. |
| packages/mcp-server/test/tools.test.ts | Adds MCP-layer tests for schema exposure, list execution, and mutation planning; no issues found. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([managePermissions]) --> B[resolve action / path]
    B --> C{action?}
    C -->|list| D[ensureNoMutationOnlyFields]
    D --> E[ydbCli run]
    E --> F[capText stdout/stderr]
    F --> G([PermissionsListResponse])
    C -->|grant / revoke / set| H[validate: no owner / normalizeNonEmpty subject / normalizePermissions]
    H --> I[build args: -p perm... path subject]
    C -->|chown| J[ensureNoMutationOnlyFields excluding owner / normalizeNonEmpty owner]
    J --> K[build args: chown path owner]
    C -->|clear / set-inheritance / clear-inheritance| L[ensureNoMutationOnlyFields]
    L --> M[build args: action path]
    I --> N[normalizedMutationFields re-validates subject + perms]
    K --> N
    M --> N
    N --> O{confirm?}
    O -->|false / absent| P([plan-only PermissionsMutationResponse executed=false])
    O -->|true| Q[runMutating execute ydbCli]
    Q --> R([executed PermissionsMutationResponse executed=true])
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Flocal-ydb-toolkit%22%20on%20the%20existing%20branch%20%22astandrik.20%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22astandrik.20%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcore%2Fsrc%2Foperations%2Fpermissions.ts%3A119-133%0A**Redundant%20re-validation%20in%20%60normalizedMutationFields%60**%0A%0A%60normalizedMutationFields%60%20calls%20%60normalizeNonEmpty%60%20and%20%60normalizePermissions%60%20on%20the%20same%20%60options%60%20fields%20that%20%60permissionsArgs%60%20already%20validated%20and%20consumed%20%28lines%2092%E2%80%9393%29.%20Because%20%60permissionsArgs%60%20runs%20first%20and%20throws%20on%20invalid%20input%2C%20this%20second%20pass%20always%20operates%20on%20already-confirmed-valid%20data.%20Consider%20extracting%20the%20normalized%20values%20once%20and%20sharing%20them%20between%20both%20callers%20to%20avoid%20the%20duplication%20and%20keep%20validation%20logic%20in%20one%20place.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fmcp-server%2Fsrc%2Ftools%2Finput-schemas.ts%3A813-878%0A**No%20%60required%60%20array%20in%20%60permissionsSchema%60**%0A%0A%60permissionsSchema%28%29%60%20lists%20all%20fields%20as%20optional%20properties%20with%20no%20%60required%60%20constraint.%20MCP%20clients%20that%20rely%20on%20JSON%20Schema%20validation%20for%20early%20feedback%20won't%20detect%20missing%20%60subject%60%2F%60permissions%60%20for%20%60grant%60%2F%60revoke%60%2F%60set%60%2C%20or%20missing%20%60owner%60%20for%20%60chown%60%2C%20until%20the%20core%20layer%20throws.%20While%20validation%20is%20correctly%20enforced%20in%20the%20core%2C%20adding%20an%20action-appropriate%20%60required%60%20array%20%28or%20documenting%20the%20intentional%20omission%29%20would%20improve%20client-side%20error%20quality.%20This%20is%20consistent%20with%20how%20%60schemeSchema%28%29%60%20is%20implemented%2C%20so%20it%20may%20be%20a%20deliberate%20pattern%20in%20this%20codebase.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcore%2Fsrc%2Foperations%2Fpermissions.ts%3A119-133%0A**Redundant%20re-validation%20in%20%60normalizedMutationFields%60**%0A%0A%60normalizedMutationFields%60%20calls%20%60normalizeNonEmpty%60%20and%20%60normalizePermissions%60%20on%20the%20same%20%60options%60%20fields%20that%20%60permissionsArgs%60%20already%20validated%20and%20consumed%20%28lines%2092%E2%80%9393%29.%20Because%20%60permissionsArgs%60%20runs%20first%20and%20throws%20on%20invalid%20input%2C%20this%20second%20pass%20always%20operates%20on%20already-confirmed-valid%20data.%20Consider%20extracting%20the%20normalized%20values%20once%20and%20sharing%20them%20between%20both%20callers%20to%20avoid%20the%20duplication%20and%20keep%20validation%20logic%20in%20one%20place.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fmcp-server%2Fsrc%2Ftools%2Finput-schemas.ts%3A813-878%0A**No%20%60required%60%20array%20in%20%60permissionsSchema%60**%0A%0A%60permissionsSchema%28%29%60%20lists%20all%20fields%20as%20optional%20properties%20with%20no%20%60required%60%20constraint.%20MCP%20clients%20that%20rely%20on%20JSON%20Schema%20validation%20for%20early%20feedback%20won't%20detect%20missing%20%60subject%60%2F%60permissions%60%20for%20%60grant%60%2F%60revoke%60%2F%60set%60%2C%20or%20missing%20%60owner%60%20for%20%60chown%60%2C%20until%20the%20core%20layer%20throws.%20While%20validation%20is%20correctly%20enforced%20in%20the%20core%2C%20adding%20an%20action-appropriate%20%60required%60%20array%20%28or%20documenting%20the%20intentional%20omission%29%20would%20improve%20client-side%20error%20quality.%20This%20is%20consistent%20with%20how%20%60schemeSchema%28%29%60%20is%20implemented%2C%20so%20it%20may%20be%20a%20deliberate%20pattern%20in%20this%20codebase.%0A%0A&repo=astandrik%2Flocal-ydb-toolkit&pr=31&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/core/src/operations/permissions.ts
Line: 119-133

Comment:
**Redundant re-validation in `normalizedMutationFields`**

`normalizedMutationFields` calls `normalizeNonEmpty` and `normalizePermissions` on the same `options` fields that `permissionsArgs` already validated and consumed (lines 92–93). Because `permissionsArgs` runs first and throws on invalid input, this second pass always operates on already-confirmed-valid data. Consider extracting the normalized values once and sharing them between both callers to avoid the duplication and keep validation logic in one place.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/mcp-server/src/tools/input-schemas.ts
Line: 813-878

Comment:
**No `required` array in `permissionsSchema`**

`permissionsSchema()` lists all fields as optional properties with no `required` constraint. MCP clients that rely on JSON Schema validation for early feedback won't detect missing `subject`/`permissions` for `grant`/`revoke`/`set`, or missing `owner` for `chown`, until the core layer throws. While validation is correctly enforced in the core, adding an action-appropriate `required` array (or documenting the intentional omission) would improve client-side error quality. This is consistent with how `schemeSchema()` is implemented, so it may be a deliberate pattern in this codebase.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: review"](https://github.com/astandrik/local-ydb-toolkit/commit/f2bb637b8b80af9f3c577d92bc621b6140bcf70f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30005862)</sub>

<!-- /greptile_comment -->