### PR TITLE
fix(deps): require patched MCP SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2433,7 +2433,7 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.18.2",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.18.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@modelcontextprotocol/sdk` from `^1.18.2` to `^1.29.0` in the `mcp-server` package to pull in a patched release; the lockfile is updated consistently to resolve the package at `1.29.0`.

- **Dependency bump**: `packages/mcp-server/package.json` version range updated; lockfile pins resolved version to `1.29.0`.
- **New transitive dependencies**: `1.29.0` adds `@hono/node-server`, `ajv@^8.17.1`, and `ajv-formats` as new transitive deps; these appear in the lockfile and are expected additions from the upstream SDK changelog.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted dependency bump with consistent lockfile, no logic changes.

The change is limited to updating one dependency version range and the corresponding lockfile entry. The resolved version (1.29.0) is the latest stable release of the upstream SDK, the lockfile integrity hash is present, and both files are internally consistent. The new transitive deps (ajv, @hono/node-server) are well-known packages introduced by the SDK itself. No application code was touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/mcp-server/package.json | Bumps `@modelcontextprotocol/sdk` dependency range from `^1.18.2` to `^1.29.0`; no other changes. |
| package-lock.json | Lockfile updated to resolve `@modelcontextprotocol/sdk` at `1.29.0`; new transitive deps (`@hono/node-server`, `ajv`, `ajv-formats`) are added and match the published package manifest. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["packages/mcp-server/package.json"] -->|"@modelcontextprotocol/sdk ^1.29.0"| B["package-lock.json\n(resolved: 1.29.0)"]
    B --> C["@hono/node-server ^1.19.9"]
    B --> D["ajv ^8.17.1"]
    B --> E["ajv-formats ^3.0.1"]
    B --> F["cors ^2.8.5"]
    B --> G["content-type ^1.0.5"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(deps): require patched MCP SDK"](https://github.com/astandrik/local-ydb-toolkit/commit/58401ae878ff838a57a1673b29c7ece7bacf3db7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31435035)</sub>

<!-- /greptile_comment -->