### PR TITLE
fix(core): publish local-ydb grpc ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Without `confirm: true`, mutating tools return planned commands, risk, rollback 
 `local_ydb_bootstrap_root_database` creates only the root local database stack:
 
 - Docker network and volume or bind mount;
-- static `ydb-local` node;
+- static `ydb-local` node with loopback-published monitoring and static gRPC ports;
 - root database verification with `scheme ls /local` through the static gRPC endpoint.
 
 Use it for generic local YDB requests when the caller did not explicitly ask for a tenant. It does not create a CMS tenant or start dynamic tenant nodes.
@@ -167,7 +167,7 @@ Use it for generic local YDB requests when the caller did not explicitly ask for
 `local_ydb_bootstrap` creates a GraphShard-ready Docker topology:
 
 - Docker network and volume or bind mount;
-- static `ydb-local` node with `YDB_FEATURE_FLAGS=enable_graph_shard`;
+- static `ydb-local` node with `YDB_FEATURE_FLAGS=enable_graph_shard` and loopback-published static and dynamic gRPC ports;
 - CMS-created tenant with `ydbd admin database /local/<tenant> create hdd:1`;
 - one dynamic tenant node.
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Without `confirm: true`, mutating tools return planned commands, risk, rollback 
 `local_ydb_bootstrap_root_database` creates only the root local database stack:
 
 - Docker network and volume or bind mount;
-- static `ydb-local` node with loopback-published monitoring and static gRPC ports;
+- static `ydb-local` node with loopback-published monitoring and static gRPC port;
 - root database verification with `scheme ls /local` through the static gRPC endpoint.
 
 Use it for generic local YDB requests when the caller did not explicitly ask for a tenant. It does not create a CMS tenant or start dynamic tenant nodes.

--- a/packages/core/src/operations/commands.ts
+++ b/packages/core/src/operations/commands.ts
@@ -9,11 +9,10 @@ export function commandForStaticRun(
 ): string {
   const enableGraphShard = options.enableGraphShard ?? true;
   const publishDynamicGrpc = options.publishDynamicGrpc ?? false;
+  validatePublishedHostPorts(profile, publishDynamicGrpc);
   const mount = profile.bindMountPath ? `${profile.bindMountPath}:/ydb_data` : `${profile.volume}:/ydb_data`;
-  const grpcPortMappings = [
-    profile.ports.staticGrpc,
-    ...(publishDynamicGrpc && profile.ports.dynamicGrpc !== profile.ports.staticGrpc ? [profile.ports.dynamicGrpc] : [])
-  ].flatMap((port) => ["-p", `127.0.0.1:${port}:${port}`]);
+  const grpcPortMappings = requiredPublishedGrpcPorts(profile, publishDynamicGrpc)
+    .flatMap((port) => ["-p", `127.0.0.1:${port}:${port}`]);
   return [
     "docker", "run", "-d",
     "--name", profile.staticContainer,
@@ -41,6 +40,7 @@ export function commandForStaticEnsureRun(
   const enableGraphShard = options.enableGraphShard ?? true;
   const requireGraphShard = options.requireGraphShard ?? false;
   const publishDynamicGrpc = options.publishDynamicGrpc ?? false;
+  validatePublishedHostPorts(profile, publishDynamicGrpc);
   const container = shellQuote(profile.staticContainer);
   const graphShardCheck = `docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' ${container} 2>/dev/null | grep -qx 'YDB_FEATURE_FLAGS=enable_graph_shard'`;
   const missingGraphShardHint = [
@@ -55,20 +55,55 @@ export function commandForStaticEnsureRun(
         "  fi"
       ]
     : [];
+  const requirePublishedGrpcLines = requiredPublishedGrpcPorts(profile, publishDynamicGrpc)
+    .flatMap((port) => [
+      `  if ! docker port ${container} ${shellQuote(`${port}/tcp`)} 2>/dev/null | grep -qx ${shellQuote(`127.0.0.1:${port}`)}; then`,
+      `    printf '%s\\n' ${shellQuote(`Existing static container ${profile.staticContainer} does not publish required gRPC port 127.0.0.1:${port}.`)} >&2`,
+      `    printf '%s\\n' ${shellQuote(`Recreate it with local_ydb_destroy_stack or docker rm -f ${profile.staticContainer}, then rerun local_ydb_bootstrap.`)} >&2`,
+      "    exit 1",
+      "  fi"
+    ]);
 
   return [
     "set -euo pipefail",
     `if docker inspect -f '{{.State.Running}}' ${container} 2>/dev/null | grep -qx true; then`,
     ...requireGraphShardLines,
+    ...requirePublishedGrpcLines,
     "  exit 0",
     "fi",
     `if docker inspect ${container} >/dev/null 2>&1; then`,
     ...requireGraphShardLines,
+    ...requirePublishedGrpcLines,
     `  docker start ${container} >/dev/null`,
     "  exit 0",
     "fi",
     commandForStaticRun(profile, { enableGraphShard, publishDynamicGrpc })
   ].join("\n");
+}
+
+function requiredPublishedGrpcPorts(profile: ResolvedLocalYdbProfile, publishDynamicGrpc: boolean): number[] {
+  return [
+    profile.ports.staticGrpc,
+    ...(publishDynamicGrpc && profile.ports.dynamicGrpc !== profile.ports.staticGrpc ? [profile.ports.dynamicGrpc] : [])
+  ];
+}
+
+function validatePublishedHostPorts(profile: ResolvedLocalYdbProfile, publishDynamicGrpc: boolean): void {
+  const bindings = [
+    { name: "staticGrpc", port: profile.ports.staticGrpc },
+    ...(publishDynamicGrpc && profile.ports.dynamicGrpc !== profile.ports.staticGrpc
+      ? [{ name: "dynamicGrpc", port: profile.ports.dynamicGrpc }]
+      : []),
+    { name: "monitoring", port: profile.ports.monitoring }
+  ];
+  const seen = new Map<number, string>();
+  for (const binding of bindings) {
+    const existing = seen.get(binding.port);
+    if (existing) {
+      throw new Error(`Profile ${profile.name} maps both ${existing} and ${binding.name} to host port ${binding.port}; published host ports must be unique.`);
+    }
+    seen.set(binding.port, binding.name);
+  }
 }
 
 export function commandForDynamicRun(profile: ResolvedLocalYdbProfile): string {

--- a/packages/core/src/operations/commands.ts
+++ b/packages/core/src/operations/commands.ts
@@ -5,16 +5,22 @@ import type { DynamicNodePlan } from "./types.js";
 
 export function commandForStaticRun(
   profile: ResolvedLocalYdbProfile,
-  options: { enableGraphShard?: boolean } = {}
+  options: { enableGraphShard?: boolean; publishDynamicGrpc?: boolean } = {}
 ): string {
   const enableGraphShard = options.enableGraphShard ?? true;
+  const publishDynamicGrpc = options.publishDynamicGrpc ?? false;
   const mount = profile.bindMountPath ? `${profile.bindMountPath}:/ydb_data` : `${profile.volume}:/ydb_data`;
+  const grpcPortMappings = [
+    profile.ports.staticGrpc,
+    ...(publishDynamicGrpc && profile.ports.dynamicGrpc !== profile.ports.staticGrpc ? [profile.ports.dynamicGrpc] : [])
+  ].flatMap((port) => ["-p", `127.0.0.1:${port}:${port}`]);
   return [
     "docker", "run", "-d",
     "--name", profile.staticContainer,
     "--no-healthcheck",
     "--network", profile.network,
     "--restart", "unless-stopped",
+    ...grpcPortMappings,
     "-p", `127.0.0.1:${profile.ports.monitoring}:8765`,
     "-v", mount,
     "-e", `GRPC_PORT=${profile.ports.staticGrpc}`,
@@ -30,10 +36,11 @@ export function commandForStaticRun(
 
 export function commandForStaticEnsureRun(
   profile: ResolvedLocalYdbProfile,
-  options: { enableGraphShard?: boolean; requireGraphShard?: boolean } = {}
+  options: { enableGraphShard?: boolean; requireGraphShard?: boolean; publishDynamicGrpc?: boolean } = {}
 ): string {
   const enableGraphShard = options.enableGraphShard ?? true;
   const requireGraphShard = options.requireGraphShard ?? false;
+  const publishDynamicGrpc = options.publishDynamicGrpc ?? false;
   const container = shellQuote(profile.staticContainer);
   const graphShardCheck = `docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' ${container} 2>/dev/null | grep -qx 'YDB_FEATURE_FLAGS=enable_graph_shard'`;
   const missingGraphShardHint = [
@@ -60,7 +67,7 @@ export function commandForStaticEnsureRun(
     `  docker start ${container} >/dev/null`,
     "  exit 0",
     "fi",
-    commandForStaticRun(profile, { enableGraphShard })
+    commandForStaticRun(profile, { enableGraphShard, publishDynamicGrpc })
   ].join("\n");
 }
 

--- a/packages/core/src/operations/stack.ts
+++ b/packages/core/src/operations/stack.ts
@@ -20,7 +20,7 @@ export async function bootstrap(ctx: ToolkitContext, options: MutatingOptions = 
     ctx.profile.bindMountPath
       ? bash(`mkdir -p ${shellQuote(ctx.profile.bindMountPath)}`, { description: "Ensure bind mount path exists" })
       : bash(`docker volume inspect ${shellQuote(ctx.profile.volume)} >/dev/null 2>&1 || docker volume create ${shellQuote(ctx.profile.volume)}`, { description: "Ensure Docker volume exists" }),
-    bash(commandForStaticEnsureRun(ctx.profile, { enableGraphShard: true, requireGraphShard: true }), { timeoutMs: 60_000, description: "Start static local-ydb node" }),
+    bash(commandForStaticEnsureRun(ctx.profile, { enableGraphShard: true, requireGraphShard: true, publishDynamicGrpc: true }), { timeoutMs: 60_000, description: "Start static local-ydb node" }),
     bash("sleep 5", { description: "Wait briefly for static node startup" }),
     createTenantSpec(ctx.profile),
     bash("sleep 5", { description: "Wait briefly for tenant creation" }),

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -62,6 +62,8 @@ describe("mutating operations", () => {
     expect(response.plannedCommands.some((command) => command.includes("docker network"))).toBe(true);
     expect(plan).toContain("-p 127.0.0.1:2136:2136");
     expect(plan).toContain("-p 127.0.0.1:2137:2137");
+    expect(plan).toContain("docker port ydb-local 2136/tcp");
+    expect(plan).toContain("docker port ydb-local 2137/tcp");
   });
 
   it("plans root database bootstrap without tenant or dynamic-node commands", async () => {
@@ -73,7 +75,9 @@ describe("mutating operations", () => {
     expect(executor.commands).toEqual([]);
     expect(plan).toContain("scheme ls /local");
     expect(plan).toContain("-p 127.0.0.1:2136:2136");
+    expect(plan).toContain("docker port ydb-local 2136/tcp");
     expect(plan).not.toContain("-p 127.0.0.1:2137:2137");
+    expect(plan).not.toContain("docker port ydb-local 2137/tcp");
     expect(plan).not.toContain("admin database");
     expect(plan).not.toContain("ydb-dyn-example");
     expect(plan).not.toContain("YDB_FEATURE_FLAGS=enable_graph_shard");
@@ -118,6 +122,54 @@ describe("mutating operations", () => {
     expect(response.results?.at(-1)?.ok).toBe(false);
     expect(response.results?.at(-1)?.stderr).toContain("YDB_FEATURE_FLAGS=enable_graph_shard");
     expect(executor.commands.some((command) => command.includes("admin database /local/example create"))).toBe(false);
+  });
+
+  it("fails tenant bootstrap before tenant creation when the static container lacks published gRPC ports", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+    executor.run = async (_profile, spec) => {
+      const command = executor.display(_profile, spec);
+      executor.commands.push(command);
+      if (command.includes("does not publish required gRPC port")) {
+        return {
+          command,
+          exitCode: 1,
+          stdout: "",
+          stderr: "Existing static container ydb-local does not publish required gRPC port 127.0.0.1:2136.",
+          ok: false,
+          timedOut: false
+        };
+      }
+      return {
+        command,
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        ok: true,
+        timedOut: false
+      };
+    };
+
+    const response = await bootstrap(ctx, { confirm: true });
+    expect(response.executed).toBe(true);
+    expect(response.results?.at(-1)?.ok).toBe(false);
+    expect(response.results?.at(-1)?.stderr).toContain("does not publish required gRPC port");
+    expect(executor.commands.some((command) => command.includes("admin database /local/example create"))).toBe(false);
+  });
+
+  it("rejects static container host-port collisions before planning bootstrap", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({
+      profiles: {
+        default: {
+          ports: {
+            monitoring: 2136
+          }
+        }
+      }
+    }));
+    await expect(bootstrapRootDatabase(ctx, {})).rejects.toThrow(/staticGrpc.*monitoring.*2136/);
+    expect(executor.commands).toEqual([]);
   });
 
   it("keeps the root bootstrap viewer probe non-fatal", async () => {

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -55,10 +55,13 @@ describe("mutating operations", () => {
     const executor = new RecordingExecutor();
     const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
     const response = await bootstrap(ctx, {});
+    const plan = response.plannedCommands.join("\n");
     expect(response.executed).toBe(false);
     expect(executor.commands).toEqual([]);
     expect(response.plannedCommands[0]).toContain("docker image inspect");
     expect(response.plannedCommands.some((command) => command.includes("docker network"))).toBe(true);
+    expect(plan).toContain("-p 127.0.0.1:2136:2136");
+    expect(plan).toContain("-p 127.0.0.1:2137:2137");
   });
 
   it("plans root database bootstrap without tenant or dynamic-node commands", async () => {
@@ -69,6 +72,8 @@ describe("mutating operations", () => {
     expect(response.executed).toBe(false);
     expect(executor.commands).toEqual([]);
     expect(plan).toContain("scheme ls /local");
+    expect(plan).toContain("-p 127.0.0.1:2136:2136");
+    expect(plan).not.toContain("-p 127.0.0.1:2137:2137");
     expect(plan).not.toContain("admin database");
     expect(plan).not.toContain("ydb-dyn-example");
     expect(plan).not.toContain("YDB_FEATURE_FLAGS=enable_graph_shard");

--- a/skills/local-ydb/references/topology.md
+++ b/skills/local-ydb/references/topology.md
@@ -21,13 +21,15 @@ Practical tag note:
 
 ## Static Node
 
-Hardened internal-gRPC static-node shape:
+Local development static-node shape for host-side clients:
 
 ```bash
 docker run -d --name ydb-local \
   --no-healthcheck \
   --network ydb-net \
   --restart unless-stopped \
+  -p 127.0.0.1:2136:2136 \
+  -p 127.0.0.1:2137:2137 \
   -p 127.0.0.1:8765:8765 \
   -v ydb-local-data:/ydb_data \
   -e GRPC_PORT=2136 \
@@ -42,7 +44,9 @@ docker run -d --name ydb-local \
 
 Notes:
 
-- `2136` should normally be Docker-internal only in a hardened deployment.
+- `2136` is the root/static gRPC endpoint for host apps using `/local`.
+- `2137` is useful when dynamic tenant nodes share `ydb-local`'s network namespace and host apps use `/local/<tenant>`.
+- In a hardened deployment, keep gRPC ports Docker-internal unless direct host access is explicitly required.
 - `8765` should be loopback-only if exposed externally through HTTPS reverse proxy.
 - `--no-healthcheck` may be required in non-TLS topology because the image healthcheck can expect `/ydb_certs/ca.pem`.
 - For bind mounts, use placeholders such as `/path/to/ydb-data:/ydb_data` in reusable docs.


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR publishes the local YDB gRPC ports to the loopback interface so host-side clients can connect without going through `docker exec`. It also adds a runtime guard that fails fast on existing containers that were created without the required port bindings, surfacing a clear recreate instruction.

- `commandForStaticRun` now builds `-p 127.0.0.1:PORT:PORT` mappings for all required gRPC ports; `commandForStaticEnsureRun` mirrors this with `docker port` checks before reusing an existing container.
- A new `validatePublishedHostPorts` helper catches host-port collisions (e.g., `monitoring == staticGrpc`) at planning time and throws before any shell script is generated.
- `bootstrap` enables `publishDynamicGrpc: true`; `bootstrapRootDatabase` implicitly gains static gRPC publishing (staticGrpc is always included by `requiredPublishedGrpcPorts`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive and self-contained, with clear error messages and no silent behaviour changes.

All code paths are covered by unit tests. The port-collision guard throws before any Docker command is emitted, the runtime check fails fast with an actionable message, and the dynamic port deduplication (`dynamicGrpc !== staticGrpc`) prevents double-binding. No logic errors or missing edge cases were found.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/operations/commands.ts | Adds `publishDynamicGrpc` option to both `commandForStaticRun` and `commandForStaticEnsureRun`; introduces `requiredPublishedGrpcPorts` and `validatePublishedHostPorts` helpers; adds runtime shell checks (`docker port`) to gate existing containers on required loopback gRPC bindings. |
| packages/core/src/operations/stack.ts | Single call-site change: `bootstrap` now passes `publishDynamicGrpc: true` to `commandForStaticEnsureRun`; `bootstrapRootDatabase` implicitly picks up static gRPC port publishing (default behaviour of `requiredPublishedGrpcPorts`). |
| packages/core/test/operations.test.ts | Adds three new test cases: plan-level port assertions for both `bootstrap` and `bootstrapRootDatabase`, a runtime failure simulation for missing gRPC port bindings, and a host-port collision rejection test. |
| README.md | Documentation updated to reflect that the static node now publishes loopback gRPC ports; separate wording for `local_ydb_bootstrap_root_database` (static only) vs. `local_ydb_bootstrap` (static + dynamic). |
| skills/local-ydb/references/topology.md | Topology reference updated with the new `-p 127.0.0.1:2136:2136` and `-p 127.0.0.1:2137:2137` port mappings and revised notes explaining each port's purpose. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[commandForStaticEnsureRun called] --> B{validatePublishedHostPorts}
    B -->|collision detected| C[throw Error immediately]
    B -->|ok| D{docker inspect Running?}
    D -->|yes| E[requirePublishedGrpcLines check]
    E -->|port missing| F[printf error >&2\nexit 1]
    E -->|ports ok| G[exit 0]
    D -->|no - container exists| H[requirePublishedGrpcLines check]
    H -->|port missing| F
    H -->|ports ok| I[docker start container\nexit 0]
    D -->|no - container absent| J[commandForStaticRun]
    J --> K[validatePublishedHostPorts again]
    K --> L[build grpcPortMappings\n-p 127.0.0.1:PORT:PORT]
    L --> M[docker run with port mappings]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/operations/commands.ts`, line 59-71 ([link](https://github.com/astandrik/local-ydb-toolkit/blob/1742e3d1b218fd4fd424890f1302308f757d2f71/packages/core/src/operations/commands.ts#L59-L71)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Existing containers silently keep old port bindings**

   `commandForStaticEnsureRun` exits early (via `docker start` or `exit 0`) when it finds an existing container, running or stopped. The new `grpcPortMappings` are only applied on a fresh `docker run`. An existing deployment that was created before this PR (gRPC ports not published) will continue to behave as before — gRPC stays unexposed — without any warning surfaced to the caller.

   `requireGraphShard` already sets a precedent for detecting mismatches between a desired flag and what an existing container has; a similar detection path (e.g. inspecting published ports via `docker inspect -f '{{json .NetworkSettings.Ports}}'`) could warn or error when the expected port bindings are absent.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/core/src/operations/commands.ts
   Line: 59-71

   Comment:
   **Existing containers silently keep old port bindings**

   `commandForStaticEnsureRun` exits early (via `docker start` or `exit 0`) when it finds an existing container, running or stopped. The new `grpcPortMappings` are only applied on a fresh `docker run`. An existing deployment that was created before this PR (gRPC ports not published) will continue to behave as before — gRPC stays unexposed — without any warning surfaced to the caller.

   `requireGraphShard` already sets a precedent for detecting mismatches between a desired flag and what an existing container has; a similar detection path (e.g. inspecting published ports via `docker inspect -f '{{json .NetworkSettings.Ports}}'`) could warn or error when the expected port bindings are absent.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Flocal-ydb-toolkit%22%20on%20the%20existing%20branch%20%22fix%2Fpublish-local-ydb-grpc-ports%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpublish-local-ydb-grpc-ports%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Foperations%2Fcommands.ts%0ALine%3A%2059-71%0A%0AComment%3A%0A**Existing%20containers%20silently%20keep%20old%20port%20bindings**%0A%0A%60commandForStaticEnsureRun%60%20exits%20early%20%28via%20%60docker%20start%60%20or%20%60exit%200%60%29%20when%20it%20finds%20an%20existing%20container%2C%20running%20or%20stopped.%20The%20new%20%60grpcPortMappings%60%20are%20only%20applied%20on%20a%20fresh%20%60docker%20run%60.%20An%20existing%20deployment%20that%20was%20created%20before%20this%20PR%20%28gRPC%20ports%20not%20published%29%20will%20continue%20to%20behave%20as%20before%20%E2%80%94%20gRPC%20stays%20unexposed%20%E2%80%94%20without%20any%20warning%20surfaced%20to%20the%20caller.%0A%0A%60requireGraphShard%60%20already%20sets%20a%20precedent%20for%20detecting%20mismatches%20between%20a%20desired%20flag%20and%20what%20an%20existing%20container%20has%3B%20a%20similar%20detection%20path%20%28e.g.%20inspecting%20published%20ports%20via%20%60docker%20inspect%20-f%20'%7B%7Bjson%20.NetworkSettings.Ports%7D%7D'%60%29%20could%20warn%20or%20error%20when%20the%20expected%20port%20bindings%20are%20absent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Foperations%2Fcommands.ts%0ALine%3A%2059-71%0A%0AComment%3A%0A**Existing%20containers%20silently%20keep%20old%20port%20bindings**%0A%0A%60commandForStaticEnsureRun%60%20exits%20early%20%28via%20%60docker%20start%60%20or%20%60exit%200%60%29%20when%20it%20finds%20an%20existing%20container%2C%20running%20or%20stopped.%20The%20new%20%60grpcPortMappings%60%20are%20only%20applied%20on%20a%20fresh%20%60docker%20run%60.%20An%20existing%20deployment%20that%20was%20created%20before%20this%20PR%20%28gRPC%20ports%20not%20published%29%20will%20continue%20to%20behave%20as%20before%20%E2%80%94%20gRPC%20stays%20unexposed%20%E2%80%94%20without%20any%20warning%20surfaced%20to%20the%20caller.%0A%0A%60requireGraphShard%60%20already%20sets%20a%20precedent%20for%20detecting%20mismatches%20between%20a%20desired%20flag%20and%20what%20an%20existing%20container%20has%3B%20a%20similar%20detection%20path%20%28e.g.%20inspecting%20published%20ports%20via%20%60docker%20inspect%20-f%20'%7B%7Bjson%20.NetworkSettings.Ports%7D%7D'%60%29%20could%20warn%20or%20error%20when%20the%20expected%20port%20bindings%20are%20absent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=astandrik%2Flocal-ydb-toolkit&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(core): validate published grpc ports"](https://github.com/astandrik/local-ydb-toolkit/commit/6e28f5f2db9315537c87e0e9f2026b1b361e25cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31439576)</sub>

<!-- /greptile_comment -->