### PR TITLE
fix: better storage prompts

### DIFF
--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -158,7 +158,7 @@ export const localYdbPromptDefinitions: readonly LocalYdbPromptDefinition[] = [
         workflowSafety,
         "Run local_ydb_status_report and local_ydb_storage_placement first to capture the current tenant and storage state.",
         "Do not try to live-decrease NumGroups. Call local_ydb_reduce_storage_groups without confirm, passing count as the number of groups to remove as a JSON number.",
-        "If local_ydb_storage_placement reports a concrete pool name such as dynamic_storage_pool:1, pass that exact value as poolName. Use poolName when the default pool lookup does not match the current stack or when local_ydb_reduce_storage_groups reports that the storage pool was not found. Include dumpName only if the user supplied it.",
+        "If local_ydb_storage_placement reports a concrete pool name such as dynamic_storage_pool:1, pass that exact value as poolName. Use poolName when the default pool lookup does not match the current stack or when local_ydb_reduce_storage_groups reports `Storage pool not found`. Include dumpName only if the user supplied it.",
         "Review the plan for tenant dump, stack teardown, rebuild with the smaller storagePoolCount, restore, verification, and auth reapply when needed before asking for execution approval.",
       ].join("\n\n");
     },

--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -50,7 +50,7 @@ export const localYdbPromptDefinitions: readonly LocalYdbPromptDefinition[] = [
       argumentBlock(args),
       workflowSafety,
       "Use this workflow when the user asks for a generic local YDB database and did not explicitly ask for a CMS tenant, GraphShard, tenant storage, dump/restore, or dynamic-node testing.",
-      "Run local_ydb_check_prerequisites first. Then call local_ydb_bootstrap_root_database without confirm to return the plan. Review the planned Docker network, storage, static node, and scheme ls /local verification before asking for approval to execute.",
+      "Run local_ydb_check_prerequisites without confirm first. Then call local_ydb_bootstrap_root_database without confirm to return the plan. Review the planned Docker network, storage, static node, and scheme ls /local verification before asking for approval to execute.",
     ].join("\n\n"),
   },
   {
@@ -63,7 +63,7 @@ export const localYdbPromptDefinitions: readonly LocalYdbPromptDefinition[] = [
       argumentBlock(args),
       workflowSafety,
       "Use this workflow only when the user needs /local/<tenant>, GraphShard, tenant storage workflows, tenant dump/restore, or dynamic-node behavior.",
-      "Run local_ydb_check_prerequisites first. Then call local_ydb_bootstrap without confirm to return the plan. Do not pass ad hoc tenant names; use the selected profile configuration unless the user updates the config outside this prompt.",
+      "Run local_ydb_check_prerequisites without confirm first. Then call local_ydb_bootstrap without confirm to return the plan. Do not pass ad hoc tenant names; use the selected profile configuration unless the user updates the config outside this prompt.",
       "After execution approval and completion, verify with local_ydb_database_status, local_ydb_tenant_check, local_ydb_nodes_check, and local_ydb_graphshard_check.",
     ].join("\n\n"),
   },
@@ -74,7 +74,7 @@ export const localYdbPromptDefinitions: readonly LocalYdbPromptDefinition[] = [
     arguments: [
       {
         name: "version",
-        description: "Target local-ydb image tag, for example 26.1.2.0.",
+        description: "Target local-ydb image tag, for example 25.2.1.7 or latest.",
         required: true,
       },
       ...commonOptionalArguments,
@@ -157,7 +157,8 @@ export const localYdbPromptDefinitions: readonly LocalYdbPromptDefinition[] = [
         argumentBlock(args),
         workflowSafety,
         "Run local_ydb_status_report and local_ydb_storage_placement first to capture the current tenant and storage state.",
-        "Do not try to live-decrease NumGroups. Call local_ydb_reduce_storage_groups without confirm, passing count as the number of groups to remove as a JSON number. Include poolName or dumpName only if the user supplied them.",
+        "Do not try to live-decrease NumGroups. Call local_ydb_reduce_storage_groups without confirm, passing count as the number of groups to remove as a JSON number.",
+        "If local_ydb_storage_placement reports a concrete pool name such as dynamic_storage_pool:1, pass that exact value as poolName. Use poolName when the default pool lookup does not match the current stack or when local_ydb_reduce_storage_groups reports that the storage pool was not found. Include dumpName only if the user supplied it.",
         "Review the plan for tenant dump, stack teardown, rebuild with the smaller storagePoolCount, restore, verification, and auth reapply when needed before asking for execution approval.",
       ].join("\n\n");
     },

--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -158,7 +158,7 @@ export const localYdbPromptDefinitions: readonly LocalYdbPromptDefinition[] = [
         workflowSafety,
         "Run local_ydb_status_report and local_ydb_storage_placement first to capture the current tenant and storage state.",
         "Do not try to live-decrease NumGroups. Call local_ydb_reduce_storage_groups without confirm, passing count as the number of groups to remove as a JSON number.",
-        "If local_ydb_storage_placement reports a concrete pool name such as dynamic_storage_pool:1, pass that exact value as poolName. Use poolName when the default pool lookup does not match the current stack or when local_ydb_reduce_storage_groups reports `Storage pool not found`. Include dumpName only if the user supplied it.",
+        "If local_ydb_storage_placement reports a concrete pool name such as dynamic_storage_pool:1, pass that exact value as poolName. Use poolName when the default pool lookup does not match the current stack. If local_ydb_reduce_storage_groups reports `Storage pool not found`, rerun it without confirm using the explicit poolName value from local_ydb_storage_placement. Include dumpName only if the user supplied it.",
         "Review the plan for tenant dump, stack teardown, rebuild with the smaller storagePoolCount, restore, verification, and auth reapply when needed before asking for execution approval.",
       ].join("\n\n");
     },

--- a/packages/mcp-server/test/tools.test.ts
+++ b/packages/mcp-server/test/tools.test.ts
@@ -197,7 +197,8 @@ describe("mcp tools", () => {
     expect(text).toContain("count as the number of groups to remove");
     expect(text).toContain("poolName");
     expect(text).toContain("dynamic_storage_pool:1");
-    expect(text).toContain("storage pool was not found");
+    expect(text).toContain("Storage pool not found");
+    expect(text).not.toContain("storage pool was not found");
     expect(text).not.toContain("storage groups to keep");
   });
 

--- a/packages/mcp-server/test/tools.test.ts
+++ b/packages/mcp-server/test/tools.test.ts
@@ -211,9 +211,19 @@ describe("mcp tools", () => {
     const tenantText = tenant.messages[0]?.content.type === "text"
       ? tenant.messages[0].content.text
       : "";
+    const rootPrerequisitesIndex = rootText.indexOf("local_ydb_check_prerequisites without confirm first");
+    const rootBootstrapIndex = rootText.indexOf("local_ydb_bootstrap_root_database without confirm");
+    const tenantPrerequisitesIndex = tenantText.indexOf("local_ydb_check_prerequisites without confirm first");
+    const tenantBootstrapIndex = tenantText.indexOf("local_ydb_bootstrap without confirm");
 
     expect(rootText).toContain("local_ydb_check_prerequisites without confirm first");
     expect(tenantText).toContain("local_ydb_check_prerequisites without confirm first");
+    expect(rootPrerequisitesIndex).toBeGreaterThanOrEqual(0);
+    expect(rootBootstrapIndex).toBeGreaterThanOrEqual(0);
+    expect(rootPrerequisitesIndex).toBeLessThan(rootBootstrapIndex);
+    expect(tenantPrerequisitesIndex).toBeGreaterThanOrEqual(0);
+    expect(tenantBootstrapIndex).toBeGreaterThanOrEqual(0);
+    expect(tenantPrerequisitesIndex).toBeLessThan(tenantBootstrapIndex);
   });
 
   it("renders every listed prompt", () => {

--- a/packages/mcp-server/test/tools.test.ts
+++ b/packages/mcp-server/test/tools.test.ts
@@ -195,7 +195,24 @@ describe("mcp tools", () => {
 
     expect(text).toContain("Plan removal of 2 storage group(s).");
     expect(text).toContain("count as the number of groups to remove");
+    expect(text).toContain("poolName");
+    expect(text).toContain("dynamic_storage_pool:1");
+    expect(text).toContain("storage pool was not found");
     expect(text).not.toContain("storage groups to keep");
+  });
+
+  it("renders bootstrap prompts with plan-only prerequisites first", () => {
+    const root = getLocalYdbPrompt("local_ydb_bootstrap_root_workflow");
+    const tenant = getLocalYdbPrompt("local_ydb_bootstrap_tenant_workflow");
+    const rootText = root.messages[0]?.content.type === "text"
+      ? root.messages[0].content.text
+      : "";
+    const tenantText = tenant.messages[0]?.content.type === "text"
+      ? tenant.messages[0].content.text
+      : "";
+
+    expect(rootText).toContain("local_ydb_check_prerequisites without confirm first");
+    expect(tenantText).toContain("local_ydb_check_prerequisites without confirm first");
   });
 
   it("renders every listed prompt", () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens three MCP prompt definitions and adds matching test coverage. The bootstrap workflow prompts now explicitly state that `local_ydb_check_prerequisites` runs without confirm, the upgrade version example tag is updated to `25.2.1.7 or latest`, and the storage-group reduction prompt gains detailed pool-name lookup guidance and a concrete recovery step when `Storage pool not found` is returned.

- **`prompts.ts`**: Prompt text-only changes across three workflow definitions; no logic or type changes.
- **`tools.test.ts`**: Extends the storage-reduction rendering test with new string assertions and adds a new test that verifies prerequisites precede bootstrap calls in both root and tenant prompts.

<h3>Confidence Score: 5/5</h3>

All changes are confined to prompt text strings and their corresponding test assertions; no runtime logic, schemas, or tool implementations are touched.

The diff is purely textual — prompt wording and test string matchers. The new storage-group guidance adds a concrete recovery path that was previously missing, and the test suite is extended to cover the new wording. Nothing here can break runtime behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/mcp-server/src/prompts.ts | Three prompt text improvements: clarifies prerequisites run without confirm, updates version example, and expands storage-group reduction guidance with concrete pool-name lookup and error-recovery instructions. |
| packages/mcp-server/test/tools.test.ts | Adds assertions for new pool-name guidance in the storage-reduction test and a new ordering test for bootstrap prerequisite prompts; contains two redundant toContain assertions already covered by the corresponding indexOf >= 0 checks. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Bootstrap Workflow] --> B[local_ydb_check_prerequisites\nwithout confirm]
    B --> C{Root or Tenant?}
    C -->|Root| D[local_ydb_bootstrap_root_database\nwithout confirm → plan]
    C -->|Tenant| E[local_ydb_bootstrap\nwithout confirm → plan]
    D --> F[User reviews plan]
    E --> F
    F --> G[Execute with confirm=true]

    H[Reduce Storage Groups Workflow] --> I[local_ydb_status_report\n+ local_ydb_storage_placement]
    I --> J[local_ydb_reduce_storage_groups\nwithout confirm → plan]
    J --> K{Storage pool not found?}
    K -->|Yes| L[Rerun with explicit poolName\nfrom local_ydb_storage_placement]
    K -->|No| M[User reviews plan]
    L --> M
    M --> N[Execute with confirm=true]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Flocal-ydb-toolkit%22%20on%20the%20existing%20branch%20%22astandrik.prompts-fix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22astandrik.prompts-fix%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fmcp-server%2Ftest%2Ftools.test.ts%3A219-221%0AThe%20two%20%60toContain%60%20assertions%20on%20lines%20219%E2%80%93220%20are%20redundant%3A%20%60rootPrerequisitesIndex%60%20and%20%60tenantPrerequisitesIndex%60%20are%20already%20checked%20with%20%60toBeGreaterThanOrEqual%280%29%60%20a%20few%20lines%20later%2C%20which%20implies%20the%20substring%20is%20present.%20Keeping%20both%20means%20any%20failure%20produces%20a%20duplicate%20report%20and%20the%20intent%20of%20the%20ordering-focused%20test%20is%20slightly%20obscured.%0A%0A%60%60%60suggestion%0A%20%20%20%20expect%28rootPrerequisitesIndex%29.toBeGreaterThanOrEqual%280%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fmcp-server%2Ftest%2Ftools.test.ts%3A219-221%0AThe%20two%20%60toContain%60%20assertions%20on%20lines%20219%E2%80%93220%20are%20redundant%3A%20%60rootPrerequisitesIndex%60%20and%20%60tenantPrerequisitesIndex%60%20are%20already%20checked%20with%20%60toBeGreaterThanOrEqual%280%29%60%20a%20few%20lines%20later%2C%20which%20implies%20the%20substring%20is%20present.%20Keeping%20both%20means%20any%20failure%20produces%20a%20duplicate%20report%20and%20the%20intent%20of%20the%20ordering-focused%20test%20is%20slightly%20obscured.%0A%0A%60%60%60suggestion%0A%20%20%20%20expect%28rootPrerequisitesIndex%29.toBeGreaterThanOrEqual%280%29%3B%0A%60%60%60%0A%0A&repo=astandrik%2Flocal-ydb-toolkit&pr=50&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/mcp-server/test/tools.test.ts:219-221
The two `toContain` assertions on lines 219–220 are redundant: `rootPrerequisitesIndex` and `tenantPrerequisitesIndex` are already checked with `toBeGreaterThanOrEqual(0)` a few lines later, which implies the substring is present. Keeping both means any failure produces a duplicate report and the intent of the ordering-focused test is slightly obscured.

```suggestion
    expect(rootPrerequisitesIndex).toBeGreaterThanOrEqual(0);
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: clarify prompt retry guidance"](https://github.com/astandrik/local-ydb-toolkit/commit/fd649fcc166d3c4e203db88375b2534072da157b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32528037)</sub>

<!-- /greptile_comment -->