### PR TITLE
fix: local-ydb upstream layout handling

### DIFF
--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -3,7 +3,7 @@ import { bash, shellQuote } from "../api-client.js";
 import { commandForDynamicRun, createTenantSpec } from "./commands.js";
 import { planOnly, runMutating } from "./execution.js";
 import { commandForStaticGeneratedConfigPath } from "./generated-config.js";
-import { escapeTextProtoString } from "./helpers.js";
+import { escapeTextProtoString, statusCommandFailureLines } from "./helpers.js";
 import type { MutatingOptions, OperationResponse, SetRootPasswordOptions, ToolkitContext } from "./types.js";
 
 export async function applyAuthHardening(ctx: ToolkitContext, options: MutatingOptions & { configHostPath?: string } = {}) {
@@ -44,7 +44,7 @@ export async function applyAuthHardening(ctx: ToolkitContext, options: MutatingO
       ...dynamicNodeRecreate
     ],
     rollback: [
-      `target=$(${targetCommand}); docker exec ${shellQuote(ctx.profile.staticContainer)} cp "$target.before-local-ydb-toolkit-auth" "$target"`,
+      `target=$(${targetCommand}) && docker exec ${shellQuote(ctx.profile.staticContainer)} cp "$target.before-local-ydb-toolkit-auth" "$target"`,
       `docker restart ${shellQuote(ctx.profile.staticContainer)}`
     ],
     verification: ["anonymous viewer/json returns 401", "authenticated tenant checks pass", "dynamic node reaches nodelist"]
@@ -70,13 +70,6 @@ function waitForAuthenticatedTenantStatusSpec(ctx: ToolkitContext) {
   );
   const retryableStatusErrors = "UNAUTHORIZED|Invalid password|Access denied|CLIENT_UNAUTHENTICATED|SCHEME_ERROR|No database found|connection refused|Endpoint list is empty|Could not resolve redirected path|Failed to connect|TRANSPORT_UNAVAILABLE";
   const retryableCreateErrors = "Group fit error|failed to allocate group|no group options";
-  const failWithStatusOutput = [
-    "    cat \"$tmp\" >&2",
-    "    if [ \"$status_rc\" -eq 0 ]; then",
-    "      exit 1",
-    "    fi",
-    "    exit \"$status_rc\""
-  ];
 
   return bash([
     "set -euo pipefail",
@@ -103,7 +96,7 @@ function waitForAuthenticatedTenantStatusSpec(ctx: ToolkitContext) {
     `  elif grep -Eq '${retryableStatusErrors}' "$tmp"; then`,
     "    sleep 2",
     "  else",
-    ...failWithStatusOutput,
+    ...statusCommandFailureLines,
     "  fi",
     "done",
     "cat \"$tmp\" >&2",

--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -2,6 +2,7 @@ import { dirname } from "node:path";
 import { bash, shellQuote } from "../api-client.js";
 import { commandForDynamicRun, createTenantSpec } from "./commands.js";
 import { planOnly, runMutating } from "./execution.js";
+import { commandForStaticGeneratedConfigPath } from "./generated-config.js";
 import { escapeTextProtoString } from "./helpers.js";
 import type { MutatingOptions, OperationResponse, SetRootPasswordOptions, ToolkitContext } from "./types.js";
 
@@ -10,7 +11,7 @@ export async function applyAuthHardening(ctx: ToolkitContext, options: MutatingO
   if (!configHostPath) {
     return planOnly(ctx, "Auth hardening requires configHostPath for the prepared YDB config.", "high", [], ["No changes."], ["Provide a reviewed configHostPath."]);
   }
-  const target = "/ydb_data/cluster/kikimr_configs/config.yaml";
+  const targetCommand = commandForStaticGeneratedConfigPath(ctx.profile.staticContainer);
   const dynamicNodeRecreate = ctx.profile.dynamicNodeAuthTokenFile
     ? [
         bash(`docker rm -f ${shellQuote(ctx.profile.dynamicContainer)} 2>/dev/null || true`),
@@ -24,19 +25,27 @@ export async function applyAuthHardening(ctx: ToolkitContext, options: MutatingO
     risk: "high",
     specs: [
       bash(`docker cp ${shellQuote(configHostPath)} ${shellQuote(`${ctx.profile.staticContainer}:/tmp/local-ydb-toolkit-config.yaml`)}`),
-      ctx.client.dockerExec(ctx.profile.staticContainer, ["cp", target, `${target}.before-local-ydb-toolkit-auth`]),
+      bash([
+        "set -euo pipefail",
+        `target=$(${targetCommand})`,
+        `docker exec ${shellQuote(ctx.profile.staticContainer)} cp "$target" "$target.before-local-ydb-toolkit-auth"`
+      ].join("\n")),
       bash(`docker stop ${shellQuote(ctx.profile.dynamicContainer)} 2>/dev/null || true`),
       bash(`docker restart ${shellQuote(ctx.profile.staticContainer)}`),
       bash("sleep 5"),
-      ctx.client.dockerExec(ctx.profile.staticContainer, ["cp", "/tmp/local-ydb-toolkit-config.yaml", target]),
+      bash([
+        "set -euo pipefail",
+        `target=$(${targetCommand})`,
+        `docker exec ${shellQuote(ctx.profile.staticContainer)} cp /tmp/local-ydb-toolkit-config.yaml "$target"`
+      ].join("\n")),
       bash(`docker restart ${shellQuote(ctx.profile.staticContainer)}`),
       bash("sleep 5"),
       ctx.profile.rootPasswordFile ? waitForAuthenticatedTenantStatusSpec(ctx) : createTenantSpec(ctx.profile),
       ...dynamicNodeRecreate
     ],
     rollback: [
-      `docker exec ${ctx.profile.staticContainer} cp ${target}.before-local-ydb-toolkit-auth ${target}`,
-      `docker restart ${ctx.profile.staticContainer}`
+      `target=$(${targetCommand}); docker exec ${shellQuote(ctx.profile.staticContainer)} cp "$target.before-local-ydb-toolkit-auth" "$target"`,
+      `docker restart ${shellQuote(ctx.profile.staticContainer)}`
     ],
     verification: ["anonymous viewer/json returns 401", "authenticated tenant checks pass", "dynamic node reaches nodelist"]
   }, options);
@@ -60,31 +69,47 @@ function waitForAuthenticatedTenantStatusSpec(ctx: ToolkitContext) {
     `/ydbd --server localhost:${ctx.profile.ports.staticGrpc} --user ${shellQuote(ctx.profile.rootUser)} --password-file /tmp/root.password admin database ${shellQuote(ctx.profile.tenantPath)} create ${shellQuote(`${ctx.profile.storagePoolKind}:${ctx.profile.storagePoolCount}`)}`
   );
   const retryableStatusErrors = "UNAUTHORIZED|Invalid password|Access denied|CLIENT_UNAUTHENTICATED|SCHEME_ERROR|No database found|connection refused|Endpoint list is empty|Could not resolve redirected path|Failed to connect|TRANSPORT_UNAVAILABLE";
+  const retryableCreateErrors = "Group fit error|failed to allocate group|no group options";
+  const failWithStatusOutput = [
+    "    cat \"$tmp\" >&2",
+    "    if [ \"$status_rc\" -eq 0 ]; then",
+    "      exit 1",
+    "    fi",
+    "    exit \"$status_rc\""
+  ];
 
   return bash([
     "set -euo pipefail",
     "tmp=$(mktemp)",
     "trap 'rm -f \"$tmp\"' EXIT",
-    "for attempt in $(seq 1 15); do",
-    `  if ${statusCommand} >"$tmp" 2>&1; then`,
-    "    cat \"$tmp\"",
-    "    exit 0",
-    "  elif grep -Eq 'State:[[:space:]]*(RUNNING|PENDING_RESOURCES)' \"$tmp\"; then",
+    "for attempt in $(seq 1 30); do",
+    "  status_rc=0",
+    `  ${statusCommand} >"$tmp" 2>&1 || status_rc=$?`,
+    "  if grep -Eq 'State:[[:space:]]*(RUNNING|PENDING_RESOURCES)' \"$tmp\"; then",
     "    cat \"$tmp\"",
     "    exit 0",
     "  elif grep -Eq 'Unknown tenant|NOT_FOUND' \"$tmp\"; then",
-    `    ${createCommand} >/dev/null 2>&1 || exit $?`,
+    "    create_rc=0",
+    `    ${createCommand} >"$tmp" 2>&1 || create_rc=$?`,
+    `    if grep -Eiq '${retryableCreateErrors}' "$tmp"; then`,
+    "      cat \"$tmp\" >&2",
+    "      sleep 2",
+    "    elif [ \"$create_rc\" -ne 0 ]; then",
+    "      cat \"$tmp\" >&2",
+    "      exit \"$create_rc\"",
+    "    else",
+    "      sleep 2",
+    "    fi",
     `  elif grep -Eq '${retryableStatusErrors}' "$tmp"; then`,
     "    sleep 2",
     "  else",
-    "    cat \"$tmp\" >&2",
-    "    exit 1",
+    ...failWithStatusOutput,
     "  fi",
     "done",
     "cat \"$tmp\" >&2",
     "exit 1"
   ].join("\n"), {
-    timeoutMs: 60_000,
+    timeoutMs: 120_000,
     redactions: [rootPasswordFile],
     description: `Wait for authenticated tenant status for ${ctx.profile.tenantPath}`
   });
@@ -109,14 +134,15 @@ export async function prepareAuthConfig(
   }
 
   const rootPasswordFile = ctx.profile.rootPasswordFile ?? "";
-  const target = "/ydb_data/cluster/kikimr_configs/config.yaml";
+  const targetCommand = commandForStaticGeneratedConfigPath(ctx.profile.staticContainer);
   const script = [
     "set -euo pipefail",
     `install -d -m 0700 ${shellQuote(dirname(configHostPath))}`,
     rootPasswordFile ? `install -d -m 0700 ${shellQuote(dirname(rootPasswordFile))}` : ":",
     "tmp=$(mktemp)",
     "trap 'rm -f \"$tmp\"' EXIT",
-    `docker exec ${shellQuote(ctx.profile.staticContainer)} cat ${shellQuote(target)} > \"$tmp\"`,
+    `target=$(${targetCommand})`,
+    `docker exec ${shellQuote(ctx.profile.staticContainer)} cat "$target" > "$tmp"`,
     [
       "ruby -ryaml -e",
       shellQuote([
@@ -202,7 +228,7 @@ export async function setRootPassword(
   const password = options.password;
   const sid = ctx.profile.dynamicNodeAuthSid ?? "root@builtin";
   const rootSid = ctx.profile.rootUser;
-  const target = "/ydb_data/cluster/kikimr_configs/config.yaml";
+  const targetCommand = commandForStaticGeneratedConfigPath(ctx.profile.staticContainer);
 
   if (!password) {
     return planOnly(
@@ -267,7 +293,8 @@ export async function setRootPassword(
     `if [ -f ${shellQuote(rootPasswordFile)} ]; then cp ${shellQuote(rootPasswordFile)} ${shellQuote(backupPassword)}; fi`,
     "cfg_tmp=$(mktemp)",
     "trap 'rm -f \"$cfg_tmp\"' EXIT",
-    `docker exec ${shellQuote(ctx.profile.staticContainer)} cat ${shellQuote(target)} > \"$cfg_tmp\"`,
+    `target=$(${targetCommand})`,
+    `docker exec ${shellQuote(ctx.profile.staticContainer)} cat "$target" > "$cfg_tmp"`,
     [
       "ruby -ryaml -e",
       shellQuote([

--- a/packages/core/src/operations/commands.ts
+++ b/packages/core/src/operations/commands.ts
@@ -1,6 +1,7 @@
 import { bash, shellQuote, type CommandSpec } from "../api-client.js";
 import type { ResolvedLocalYdbProfile } from "../validation.js";
 import { generatedConfigDiscoveryLines } from "./generated-config.js";
+import { statusCommandFailureLines } from "./helpers.js";
 import { ensureImagePresentSpec } from "./images.js";
 import type { DynamicNodePlan } from "./types.js";
 
@@ -219,13 +220,6 @@ export function createTenantSpec(profile: ResolvedLocalYdbProfile): CommandSpec 
   const createCommand = dockerExecYdbd(profile, createArgs);
   const retryableStatusErrors = "SCHEME_ERROR|No database found|connection refused|Endpoint list is empty|Could not resolve redirected path|Failed to connect|TRANSPORT_UNAVAILABLE";
   const retryableCreateErrors = "Group fit error|failed to allocate group|no group options";
-  const failWithStatusOutput = [
-    "    cat \"$tmp\" >&2",
-    "    if [ \"$status_rc\" -eq 0 ]; then",
-    "      exit 1",
-    "    fi",
-    "    exit \"$status_rc\""
-  ];
   return bash([
     "set -euo pipefail",
     "tmp=$(mktemp)",
@@ -251,7 +245,7 @@ export function createTenantSpec(profile: ResolvedLocalYdbProfile): CommandSpec 
     `  elif grep -Eq '${retryableStatusErrors}' "$tmp"; then`,
     "    sleep 2",
     "  else",
-    ...failWithStatusOutput,
+    ...statusCommandFailureLines,
     "  fi",
     "done",
     "cat \"$tmp\" >&2",

--- a/packages/core/src/operations/commands.ts
+++ b/packages/core/src/operations/commands.ts
@@ -1,5 +1,6 @@
 import { bash, shellQuote, type CommandSpec } from "../api-client.js";
 import type { ResolvedLocalYdbProfile } from "../validation.js";
+import { generatedConfigDiscoveryLines } from "./generated-config.js";
 import { ensureImagePresentSpec } from "./images.js";
 import type { DynamicNodePlan } from "./types.js";
 
@@ -135,9 +136,10 @@ export function commandForDynamicNodeRun(profile: ResolvedLocalYdbProfile, node:
   const innerCommand = [
     "set -euo pipefail",
     "cfg=/tmp/local-ydb-dynamic-config.yaml",
-    "sed -e '/^  ca: \\/ydb_certs\\/ca\\.pem$/d' -e '/^  cert: \\/ydb_certs\\/cert\\.pem$/d' -e '/^  key: \\/ydb_certs\\/key\\.pem$/d' /ydb_data/cluster/kikimr_configs/config.yaml > \"$cfg\"",
+    ...generatedConfigDiscoveryLines("source_config"),
+    "sed -e '/^  ca: \\/ydb_certs\\/ca\\.pem$/d' -e '/^  cert: \\/ydb_certs\\/cert\\.pem$/d' -e '/^  key: \\/ydb_certs\\/key\\.pem$/d' \"$source_config\" > \"$cfg\"",
     `exec /ydbd server --yaml-config "$cfg" ${dynamicArgs}`
-  ].join("; ");
+  ].join("\n");
   return [
     "docker", "run", "-d",
     "--name", node.container,
@@ -216,31 +218,46 @@ export function createTenantSpec(profile: ResolvedLocalYdbProfile): CommandSpec 
   const statusCommand = dockerExecYdbd(profile, statusArgs);
   const createCommand = dockerExecYdbd(profile, createArgs);
   const retryableStatusErrors = "SCHEME_ERROR|No database found|connection refused|Endpoint list is empty|Could not resolve redirected path|Failed to connect|TRANSPORT_UNAVAILABLE";
+  const retryableCreateErrors = "Group fit error|failed to allocate group|no group options";
+  const failWithStatusOutput = [
+    "    cat \"$tmp\" >&2",
+    "    if [ \"$status_rc\" -eq 0 ]; then",
+    "      exit 1",
+    "    fi",
+    "    exit \"$status_rc\""
+  ];
   return bash([
     "set -euo pipefail",
     "tmp=$(mktemp)",
     "trap 'rm -f \"$tmp\"' EXIT",
-    "for attempt in $(seq 1 15); do",
-    `  if ${statusCommand} >"$tmp" 2>&1; then`,
-    "    cat \"$tmp\"",
-    "    exit 0",
-    "  elif grep -Eq 'State:[[:space:]]*(RUNNING|PENDING_RESOURCES)' \"$tmp\"; then",
+    "for attempt in $(seq 1 30); do",
+    "  status_rc=0",
+    `  ${statusCommand} >"$tmp" 2>&1 || status_rc=$?`,
+    "  if grep -Eq 'State:[[:space:]]*(RUNNING|PENDING_RESOURCES)' \"$tmp\"; then",
     "    cat \"$tmp\"",
     "    exit 0",
     "  elif grep -Eq 'Unknown tenant|NOT_FOUND' \"$tmp\"; then",
-    `    ${createCommand} >/dev/null 2>&1 || exit $?`,
+    "    create_rc=0",
+    `    ${createCommand} >"$tmp" 2>&1 || create_rc=$?`,
+    `    if grep -Eiq '${retryableCreateErrors}' "$tmp"; then`,
+    "      cat \"$tmp\" >&2",
+    "      sleep 2",
+    "    elif [ \"$create_rc\" -ne 0 ]; then",
+    "      cat \"$tmp\" >&2",
+    "      exit \"$create_rc\"",
+    "    else",
+    "      sleep 2",
+    "    fi",
     `  elif grep -Eq '${retryableStatusErrors}' "$tmp"; then`,
-    "    :",
+    "    sleep 2",
     "  else",
-    "    cat \"$tmp\" >&2",
-    "    exit 1",
+    ...failWithStatusOutput,
     "  fi",
-    "  sleep 2",
     "done",
     "cat \"$tmp\" >&2",
     "exit 1"
   ].join("\n"), {
-    timeoutMs: 60_000,
+    timeoutMs: 120_000,
     description: "Create CMS tenant if missing"
   });
 }

--- a/packages/core/src/operations/generated-config.ts
+++ b/packages/core/src/operations/generated-config.ts
@@ -1,0 +1,52 @@
+import { shellQuote } from "../api-client.js";
+
+const GENERATED_CONFIG_CANDIDATES = [
+  "/ydb_data/cluster/kikimr_configs/config.yaml",
+  "/ydb_data/kikimr_configs/config.yaml"
+] as const;
+
+export function generatedConfigDiscoveryLines(variableName: string): string[] {
+  assertShellVariableName(variableName);
+  return [
+    `${variableName}=`,
+    `for candidate in ${GENERATED_CONFIG_CANDIDATES.map(shellQuote).join(" ")}; do`,
+    "  if [ -f \"$candidate\" ]; then",
+    `    ${variableName}=$candidate`,
+    "    break",
+    "  fi",
+    "done",
+    `if [ -z "$${variableName}" ]; then`,
+    "  matches=$(find /ydb_data -maxdepth 4 -type f -path '*/kikimr_configs/config.yaml' 2>/dev/null | sort)",
+    "  match_count=$(printf '%s\\n' \"$matches\" | grep -c . || true)",
+    "  case \"$match_count\" in",
+    "    0)",
+    "      printf '%s\\n' 'local-ydb generated config.yaml was not found under /ydb_data' >&2",
+    "      exit 1",
+    "      ;;",
+    "    1)",
+    `      ${variableName}=$matches`,
+    "      ;;",
+    "    *)",
+    "      printf '%s\\n' 'multiple local-ydb generated config.yaml files found under /ydb_data:' >&2",
+    "      printf '%s\\n' \"$matches\" >&2",
+    "      exit 1",
+    "      ;;",
+    "  esac",
+    "fi"
+  ];
+}
+
+export function commandForStaticGeneratedConfigPath(staticContainer: string): string {
+  const variableName = "generated_config";
+  const script = [
+    ...generatedConfigDiscoveryLines(variableName),
+    `printf '%s\\n' "$${variableName}"`
+  ].join("\n");
+  return `docker exec ${shellQuote(staticContainer)} sh -lc ${shellQuote(script)}`;
+}
+
+function assertShellVariableName(variableName: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(variableName)) {
+    throw new Error(`Invalid shell variable name: ${variableName}`);
+  }
+}

--- a/packages/core/src/operations/helpers.ts
+++ b/packages/core/src/operations/helpers.ts
@@ -62,6 +62,14 @@ export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+export const statusCommandFailureLines = [
+  "    cat \"$tmp\" >&2",
+  "    if [ \"$status_rc\" -eq 0 ]; then",
+  "      exit 1",
+  "    fi",
+  "    exit \"$status_rc\""
+];
+
 export function observedNodePorts(nodes: unknown[]): number[] {
   return nodes
     .map((node) => node && typeof node === "object" ? (node as Record<string, unknown>).Port : undefined)

--- a/packages/core/src/operations/tenant.ts
+++ b/packages/core/src/operations/tenant.ts
@@ -3,6 +3,8 @@ import { createTenantSpec, helperContainer, ydbAuthArgs } from "./commands.js";
 import { planOnly, runMutating } from "./execution.js";
 import type { MutatingOptions, ToolkitContext } from "./types.js";
 
+const SYSTEM_PATH_EXCLUDE_PATTERN = "(^|/)\\.sys(/|$)";
+
 export async function createTenant(ctx: ToolkitContext, options: MutatingOptions = {}) {
   return runMutating(ctx, {
     summary: `Create CMS tenant ${ctx.profile.tenantPath}.`,
@@ -18,7 +20,7 @@ export async function dumpTenant(ctx: ToolkitContext, options: MutatingOptions &
   const dumpPath = `${ctx.profile.dumpHostPath}/${dumpName}`;
   const specs = [
     bash(`mkdir -p ${shellQuote(dumpPath)}`),
-    helperContainer(ctx.profile, `/ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} ${ydbAuthArgs(ctx.profile)} tools dump -p . -o ${shellQuote(`/dump/${dumpName}/tenant`)}`)
+    helperContainer(ctx.profile, `/ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} ${ydbAuthArgs(ctx.profile)} tools dump -p . --exclude ${shellQuote(SYSTEM_PATH_EXCLUDE_PATTERN)} -o ${shellQuote(`/dump/${dumpName}/tenant`)}`)
   ];
   return runMutating(ctx, {
     summary: `Dump ${ctx.profile.tenantPath} to ${dumpPath}.`,

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -323,6 +323,8 @@ describe("mutating operations", () => {
     const response = await dumpTenant(ctx, { dumpName: "mcp-smoke" });
     expect(response.executed).toBe(false);
     expect(response.plannedCommands[0]).toContain("mkdir -p /tmp/local-ydb-dump/mcp-smoke");
+    expect(response.plannedCommands[1]).toContain("tools dump -p . --exclude");
+    expect(response.plannedCommands[1]).toContain("'(^|/)\\.sys(/|$)'");
     expect(response.plannedCommands[1]).toContain("-o /dump/mcp-smoke/tenant");
   });
 
@@ -331,10 +333,15 @@ describe("mutating operations", () => {
     const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
     const response = await createTenant(ctx, {});
     expect(response.executed).toBe(false);
+    expect(response.plannedCommands[0]).toContain("status_rc=0");
+    expect(response.plannedCommands[0]).toContain("status_rc=$?");
+    expect(response.plannedCommands[0]).toContain("create_rc=0");
     expect(response.plannedCommands[0]).toContain("Unknown tenant|NOT_FOUND");
     expect(response.plannedCommands[0]).toContain("State:[[:space:]]*(RUNNING|PENDING_RESOURCES)");
     expect(response.plannedCommands[0]).toContain("SCHEME_ERROR|No database found");
+    expect(response.plannedCommands[0]).toContain("Group fit error|failed to allocate group|no group options");
     expect(response.plannedCommands[0]).toContain("sleep 2");
+    expect(response.plannedCommands[0]).not.toContain("if docker exec ydb-local /ydbd --server localhost:2136 --no-password admin database /local/example status >\"$tmp\" 2>&1; then");
   });
 
   it("treats readable tenant status as success when ydbd returns non-zero", async () => {
@@ -387,6 +394,10 @@ describe("mutating operations", () => {
     expect(response.plannedCommands[1]).toContain("-e GRPC_TLS_PORT=");
     expect(response.plannedCommands[1]).toContain("-e YDB_GRPC_ENABLE_TLS=0");
     expect(response.plannedCommands[1]).toContain("local-ydb-dynamic-config.yaml");
+    expect(response.plannedCommands[1]).toContain("/ydb_data/cluster/kikimr_configs/config.yaml");
+    expect(response.plannedCommands[1]).toContain("/ydb_data/kikimr_configs/config.yaml");
+    expect(response.plannedCommands[1]).toContain("\"$source_config\"");
+    expect(response.plannedCommands[1]).not.toContain("sed -e '/^  ca: \\/ydb_certs\\/ca\\.pem$/d' -e '/^  cert: \\/ydb_certs\\/cert\\.pem$/d' -e '/^  key: \\/ydb_certs\\/key\\.pem$/d' /ydb_data/cluster/kikimr_configs/config.yaml");
     expect(response.plannedCommands[1]).toContain("/tmp/local-ydb-auth.pb:/run/local-ydb/dynamic-node-auth.pb:ro");
     expect(response.plannedCommands[1]).toContain("--auth-token-file /run/local-ydb/dynamic-node-auth.pb");
   });
@@ -857,12 +868,12 @@ describe("mutating operations", () => {
     expect(commands.some((command) => command.includes("/dump/shrink-smoke/tenant"))).toBe(true);
     expect(commands.some((command) => command.includes("admin database /local/example create hdd:1"))).toBe(true);
     expect(commands.filter((command) => command.includes("docker restart ydb-local")).length).toBe(2);
-    expect(commands.some((command) => command.includes("cp /tmp/local-ydb-toolkit-config.yaml /ydb_data/cluster/kikimr_configs/config.yaml"))).toBe(true);
+    expect(commands.some((command) => command.includes("cp /tmp/local-ydb-toolkit-config.yaml \"$target\""))).toBe(true);
     expect(commands.some((command) => command.includes("StaffApiUserToken: \"root@builtin\""))).toBe(true);
     expect(commands.some((command) => command.includes("--name ydb-dyn-example-2"))).toBe(true);
 
     const firstRestartIndex = commands.findIndex((command) => command.includes("docker restart ydb-local"));
-    const recopyIndex = commands.findIndex((command) => command.includes("cp /tmp/local-ydb-toolkit-config.yaml /ydb_data/cluster/kikimr_configs/config.yaml"));
+    const recopyIndex = commands.findIndex((command) => command.includes("cp /tmp/local-ydb-toolkit-config.yaml \"$target\""));
     const secondRestartIndex = commands.findIndex((command, index) => index > firstRestartIndex && command.includes("docker restart ydb-local"));
     const readdExtraNodeIndex = commands.findIndex((command) => command.includes("--name ydb-dyn-example-2"));
     expect(firstRestartIndex).toBeGreaterThan(-1);
@@ -1085,11 +1096,12 @@ describe("mutating operations", () => {
     expect(response.plannedCommands.filter((command) => command.includes("docker restart ydb-local")).length).toBe(2);
     expect(response.plannedCommands.join("\n")).toContain("State:[[:space:]]*(RUNNING|PENDING_RESOURCES)");
     const firstRestartIndex = response.plannedCommands.findIndex((command) => command.includes("docker restart ydb-local"));
-    const recopyIndex = response.plannedCommands.findIndex((command) => command.includes("cp /tmp/local-ydb-toolkit-config.yaml /ydb_data/cluster/kikimr_configs/config.yaml"));
+    const recopyIndex = response.plannedCommands.findIndex((command) => command.includes("cp /tmp/local-ydb-toolkit-config.yaml \"$target\""));
     expect(recopyIndex).toBeGreaterThan(firstRestartIndex);
     expect(response.plannedCommands.some((command) => command.includes("docker rm -f ydb-dyn-example"))).toBe(true);
     expect(response.plannedCommands.some((command) => command.includes("--auth-token-file /run/local-ydb/dynamic-node-auth.pb"))).toBe(true);
     expect(response.plannedCommands.join("\n")).toContain("SCHEME_ERROR|No database found");
+    expect(response.plannedCommands.join("\n")).toContain("Group fit error|failed to allocate group|no group options");
   });
 
   it("plans root password rotation without exposing the password", async () => {
@@ -1119,6 +1131,9 @@ describe("mutating operations", () => {
     expect(response.plannedCommands[0]).toContain("/tmp/local-ydb/config.auth.yaml");
     expect(response.plannedCommands.join("\n")).not.toContain("S3cr3t! rotate me");
     expect(response.plannedCommands.some((command) => command.includes("ALTER USER root PASSWORD"))).toBe(true);
+    expect(response.plannedCommands[1]).toContain("target=$(docker exec ydb-local sh -lc");
+    expect(response.plannedCommands[1]).toContain("/ydb_data/kikimr_configs/config.yaml");
+    expect(response.plannedCommands[1]).toContain("docker exec ydb-local cat \"$target\"");
     expect(response.plannedCommands.filter((command) => command.includes("docker restart ydb-local")).length).toBe(0);
     expect(response.plannedCommands.some((command) => command.includes("viewer/json/whoami"))).toBe(true);
   });
@@ -1145,7 +1160,11 @@ describe("mutating operations", () => {
     }));
     const response = await prepareAuthConfig(ctx, {});
     expect(response.executed).toBe(false);
-    expect(response.plannedCommands[0]).toContain("docker exec ydb-local cat /ydb_data/cluster/kikimr_configs/config.yaml");
+    expect(response.plannedCommands[0]).toContain("target=$(docker exec ydb-local sh -lc");
+    expect(response.plannedCommands[0]).toContain("/ydb_data/cluster/kikimr_configs/config.yaml");
+    expect(response.plannedCommands[0]).toContain("/ydb_data/kikimr_configs/config.yaml");
+    expect(response.plannedCommands[0]).toContain("docker exec ydb-local cat \"$target\"");
+    expect(response.plannedCommands[0]).not.toContain("docker exec ydb-local cat /ydb_data/cluster/kikimr_configs/config.yaml");
     expect(response.plannedCommands[0]).toContain("/tmp/local-ydb/config.auth.yaml");
     expect(response.plannedCommands[0]).toContain("/tmp/local-ydb/root.password");
     expect(response.plannedCommands[0]).toContain("register_dynamic_node_allowed_sids");


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the hardcoded YDB config path `/ydb_data/cluster/kikimr_configs/config.yaml` with a two-candidate probe followed by a `find`-based fallback, allowing the toolkit to handle both the old and new upstream container layouts.

- `generated-config.ts` introduces `generatedConfigDiscoveryLines` (inline shell) and `commandForStaticGeneratedConfigPath` (docker-exec wrapper), used across auth operations, dynamic-node startup, and config reading.
- The tenant status/create loop in `commands.ts` and `auth-operations.ts` is hardened: retryable create errors (`Group fit error`, storage group allocation failures) are retried instead of exiting immediately, the loop limit doubles to 30, timeout doubles to 120 s, and `statusCommandFailureLines` is extracted to avoid duplication.
- `tenant.ts` adds `--exclude '(^|/)\\.sys(/|$)'` to `dumpTenant` to prevent dumping internal YDB system paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the config discovery logic is correct, all error paths exit explicitly, and the loop refactoring is well-tested.

The dynamic path discovery handles both candidate layouts and falls back to `find` with clear multi-match and no-match error messages. The tenant loop changes address real transient failures without introducing new incorrect states. Tests cover the new discovery output, retryable error strings, and changed loop structure.

packages/core/src/operations/generated-config.ts — the `commandForStaticGeneratedConfigPath` script lacks `set -euo pipefail` unlike every other multi-command script in the codebase.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/operations/generated-config.ts | New module providing dynamic YDB config path discovery; logic is sound but `commandForStaticGeneratedConfigPath` runs without `set -euo pipefail`, making it inconsistent with other scripts. |
| packages/core/src/operations/auth-operations.ts | Hardcoded config path replaced by dynamic discovery; rollback now uses `&&` chaining (previous thread resolved); logic is correct. |
| packages/core/src/operations/commands.ts | Tenant status/create loop overhauled with retryable create errors, proper exit-code propagation, and doubled timeout; previously duplicated failure lines extracted to shared helper. |
| packages/core/src/operations/helpers.ts | Adds `statusCommandFailureLines` constant shared across both tenant loops; indentation (4 spaces) is correctly aligned with call sites. |
| packages/core/src/operations/tenant.ts | Adds `--exclude '(^|/)\.sys(/|$)'` to `dumpTenant` to skip internal `.sys` paths; straightforward and correct. |
| packages/core/test/operations.test.ts | Test assertions updated to match new dynamic-path behavior; adds coverage for retryable create errors, dynamic config discovery, and `.sys` exclusion. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Need config path] --> B{Check candidate 1\n/ydb_data/cluster/kikimr_configs/config.yaml}
    B -- exists --> E[Use candidate 1]
    B -- not found --> C{Check candidate 2\n/ydb_data/kikimr_configs/config.yaml}
    C -- exists --> E
    C -- not found --> D[find /ydb_data -maxdepth 4\n-path '*/kikimr_configs/config.yaml']
    D --> F{match_count?}
    F -- 0 --> G[exit 1: not found]
    F -- 1 --> E
    F -- 2+ --> H[exit 1: ambiguous]
    E --> I{Context}
    I -- static container\ncommandForStaticGeneratedConfigPath --> J[docker exec static\nsh -lc discovery script\nprint path to stdout]
    I -- dynamic container\ngeneratedConfigDiscoveryLines --> K[inline shell lines\nset source_config=path\nused by sed + exec ydbd]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Flocal-ydb-toolkit%22%20on%20the%20existing%20branch%20%22fix%2Flocal-ydb-upstream-layout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Flocal-ydb-upstream-layout%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcore%2Fsrc%2Foperations%2Fgenerated-config.ts%3A41-44%0AThe%20discovery%20script%20run%20by%20%60commandForStaticGeneratedConfigPath%60%20has%20no%20%60set%20-euo%20pipefail%60%20guard%20%28unlike%20every%20other%20multi-command%20script%20in%20the%20codebase%29.%20Without%20it%2C%20a%20failed%20%60find%60%20or%20%60sort%60%20step%20is%20silently%20swallowed%2C%20and%20the%20%60%24generated_config%60%20variable%20stays%20empty.%20The%20explicit%20%60exit%201%60%20branches%20do%20fire%20correctly%2C%20but%20an%20unexpected%20failure%20mid-script%20could%20produce%20a%20blank%20path%20that%20propagates%20to%20the%20caller.%20Adding%20the%20guard%20at%20the%20top%20of%20the%20script%20is%20consistent%20with%20%60commandForDynamicNodeRun%60%20and%20the%20other%20discovery%20sites.%0A%0A%60%60%60suggestion%0A%20%20const%20script%20%3D%20%5B%0A%20%20%20%20%22set%20-euo%20pipefail%22%2C%0A%20%20%20%20...generatedConfigDiscoveryLines%28variableName%29%2C%0A%20%20%20%20%60printf%20'%25s%5C%5Cn'%20%22%24%24%7BvariableName%7D%22%60%0A%20%20%5D.join%28%22%5Cn%22%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fcore%2Fsrc%2Foperations%2Fgenerated-config.ts%3A41-44%0AThe%20discovery%20script%20run%20by%20%60commandForStaticGeneratedConfigPath%60%20has%20no%20%60set%20-euo%20pipefail%60%20guard%20%28unlike%20every%20other%20multi-command%20script%20in%20the%20codebase%29.%20Without%20it%2C%20a%20failed%20%60find%60%20or%20%60sort%60%20step%20is%20silently%20swallowed%2C%20and%20the%20%60%24generated_config%60%20variable%20stays%20empty.%20The%20explicit%20%60exit%201%60%20branches%20do%20fire%20correctly%2C%20but%20an%20unexpected%20failure%20mid-script%20could%20produce%20a%20blank%20path%20that%20propagates%20to%20the%20caller.%20Adding%20the%20guard%20at%20the%20top%20of%20the%20script%20is%20consistent%20with%20%60commandForDynamicNodeRun%60%20and%20the%20other%20discovery%20sites.%0A%0A%60%60%60suggestion%0A%20%20const%20script%20%3D%20%5B%0A%20%20%20%20%22set%20-euo%20pipefail%22%2C%0A%20%20%20%20...generatedConfigDiscoveryLines%28variableName%29%2C%0A%20%20%20%20%60printf%20'%25s%5C%5Cn'%20%22%24%24%7BvariableName%7D%22%60%0A%20%20%5D.join%28%22%5Cn%22%29%3B%0A%60%60%60%0A%0A&repo=astandrik%2Flocal-ydb-toolkit&pr=52&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/core/src/operations/generated-config.ts:41-44
The discovery script run by `commandForStaticGeneratedConfigPath` has no `set -euo pipefail` guard (unlike every other multi-command script in the codebase). Without it, a failed `find` or `sort` step is silently swallowed, and the `$generated_config` variable stays empty. The explicit `exit 1` branches do fire correctly, but an unexpected failure mid-script could produce a blank path that propagates to the caller. Adding the guard at the top of the script is consistent with `commandForDynamicNodeRun` and the other discovery sites.

```suggestion
  const script = [
    "set -euo pipefail",
    ...generatedConfigDiscoveryLines(variableName),
    `printf '%s\\n' "$${variableName}"`
  ].join("\n");
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address PR review feedback"](https://github.com/astandrik/local-ydb-toolkit/commit/b3d45ad54c4a4c0e2b45c051a55abe00108ae784) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32589046)</sub>

<!-- /greptile_comment -->