### PR TITLE
fix(core): harden local-ydb lifecycle readiness

### DIFF
--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -1,6 +1,6 @@
 import { dirname } from "node:path";
 import { bash, shellQuote } from "../api-client.js";
-import { commandForDynamicRun, createTenantSpec } from "./commands.js";
+import { commandForDynamicRun, createTenantSpec, waitForYdbCli } from "./commands.js";
 import { planOnly, runMutating } from "./execution.js";
 import { commandForStaticGeneratedConfigPath } from "./generated-config.js";
 import { escapeTextProtoString, statusCommandFailureLines } from "./helpers.js";
@@ -41,7 +41,10 @@ export async function applyAuthHardening(ctx: ToolkitContext, options: MutatingO
       bash(`docker restart ${shellQuote(ctx.profile.staticContainer)}`),
       bash("sleep 5"),
       ctx.profile.rootPasswordFile ? waitForAuthenticatedTenantStatusSpec(ctx) : createTenantSpec(ctx.profile),
-      ...dynamicNodeRecreate
+      ...dynamicNodeRecreate,
+      ...(ctx.profile.rootPasswordFile
+        ? [waitForYdbCli(ctx.profile, ["scheme", "ls", ctx.profile.tenantPath], ctx.profile.tenantPath, "Wait for authenticated tenant metadata")]
+        : [])
     ],
     rollback: [
       `target=$(${targetCommand}) && docker exec ${shellQuote(ctx.profile.staticContainer)} cp "$target.before-local-ydb-toolkit-auth" "$target"`,
@@ -251,11 +254,12 @@ export async function setRootPassword(
   const rotateSpec = bash([
     "set -euo pipefail",
     "candidate=$(mktemp)",
-    "trap 'rm -f \"$candidate\"' EXIT",
+    "last_error=$(mktemp)",
+    "trap 'rm -f \"$candidate\" \"$last_error\"' EXIT",
     `rotate_with_password_file() {
   local file="$1"
   [ -f "$file" ] || return 1
-  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`umask 077; cat >/tmp/root.password; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file /tmp/root.password yql -s "ALTER USER ${ctx.profile.rootUser} PASSWORD '${escapedPassword}';"; rc=$?; rm -f /tmp/root.password; exit $rc`)} >/dev/null 2>&1
+  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`umask 077; cat >/tmp/root.password; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file /tmp/root.password yql -s "ALTER USER ${ctx.profile.rootUser} PASSWORD '${escapedPassword}';"; rc=$?; rm -f /tmp/root.password; exit $rc`)} >"$last_error" 2>&1
 }`,
     `extract_password_from_config() {
   local file="$1"
@@ -271,7 +275,8 @@ export async function setRootPassword(
     `if rotate_with_password_file ${shellQuote(backupPassword)}; then exit 0; fi`,
     `if extract_password_from_config ${shellQuote(configHostPath)} && rotate_with_password_file "$candidate"; then exit 0; fi`,
     `if extract_password_from_config ${shellQuote(backupConfig)} && rotate_with_password_file "$candidate"; then exit 0; fi`,
-    "echo 'Unable to authenticate as root with any known password source' >&2",
+    "echo 'Unable to authenticate as root with any known password source or ALTER USER failed' >&2",
+    "cat \"$last_error\" >&2",
     "exit 1"
   ].join("\n"), {
     redactions: [password, escapedPassword, backupPassword, backupConfig],

--- a/packages/core/src/operations/commands.ts
+++ b/packages/core/src/operations/commands.ts
@@ -272,35 +272,46 @@ export function ydbCli(profile: ResolvedLocalYdbProfile, args: string[], databas
   };
 }
 
-export function waitForYdbCli(profile: ResolvedLocalYdbProfile, args: string[], database: string, description: string, options: { root?: boolean } = {}): CommandSpec {
-  const command = options.root
-    ? commandForYdbRootCli(profile, args)
-    : commandForYdbCli(profile, args, database);
-  const retryableErrors = "CLIENT_UNAUTHENTICATED|SCHEME_ERROR|No database found|connection refused|Endpoint list is empty|Could not resolve redirected path|Failed to connect|TRANSPORT_UNAVAILABLE|UNAVAILABLE";
+export function waitForCommand(
+  command: string,
+  description: string,
+  retryableErrors: string,
+  options: { redactions?: string[]; timeoutMs?: number; maxAttempts?: number; retryDelaySeconds?: number } = {}
+): CommandSpec {
+  const maxAttempts = options.maxAttempts ?? 30;
+  const retryDelaySeconds = options.retryDelaySeconds ?? 2;
   return bash([
     "set -euo pipefail",
     "tmp=$(mktemp)",
     "trap 'rm -f \"$tmp\"' EXIT",
-    "for attempt in $(seq 1 30); do",
+    `for attempt in $(seq 1 ${maxAttempts}); do`,
     "  rc=0",
-    `  ${command} >"$tmp" 2>&1 || rc=$?`,
+    `  ( ${command} ) >"$tmp" 2>&1 || rc=$?`,
     "  if [ \"$rc\" -eq 0 ]; then",
     "    cat \"$tmp\"",
     "    exit 0",
     "  fi",
     `  if grep -Eiq '${retryableErrors}' "$tmp"; then`,
-    "    sleep 2",
+    `    sleep ${retryDelaySeconds}`,
     "  else",
     "    cat \"$tmp\" >&2",
     "    exit \"$rc\"",
     "  fi",
     "done",
     "cat \"$tmp\" >&2",
-    "exit 1"
+    "exit \"$rc\""
   ].join("\n"), {
     allowFailure: true,
-    timeoutMs: 120_000,
+    timeoutMs: options.timeoutMs ?? 120_000,
     description,
+    redactions: options.redactions
+  });
+}
+
+export function waitForYdbCli(profile: ResolvedLocalYdbProfile, args: string[], database: string, description: string): CommandSpec {
+  const command = commandForYdbCli(profile, args, database);
+  const retryableErrors = "CLIENT_UNAUTHENTICATED|SCHEME_ERROR|No database found|connection refused|Endpoint list is empty|Could not resolve redirected path|Failed to connect|TRANSPORT_UNAVAILABLE|Status:[[:space:]]*UNAVAILABLE";
+  return waitForCommand(command, description, retryableErrors, {
     redactions: [profile.rootPasswordFile ?? ""]
   });
 }

--- a/packages/core/src/operations/commands.ts
+++ b/packages/core/src/operations/commands.ts
@@ -258,7 +258,11 @@ export function createTenantSpec(profile: ResolvedLocalYdbProfile): CommandSpec 
 
 export function ydbCli(profile: ResolvedLocalYdbProfile, args: string[], database: string, description: string): CommandSpec {
   if (profile.rootPasswordFile) {
-    return passwordPipedDockerExec(profile, `/ydb -e grpc://localhost:${profile.ports.dynamicGrpc} -d ${shellQuote(database)} --user ${shellQuote(profile.rootUser)} --password-file /tmp/root.password ${args.map(shellQuote).join(" ")}`, description);
+    return bash(commandForYdbCli(profile, args, database), {
+      allowFailure: true,
+      description,
+      redactions: [profile.rootPasswordFile]
+    });
   }
   return {
     command: "docker",
@@ -268,17 +272,69 @@ export function ydbCli(profile: ResolvedLocalYdbProfile, args: string[], databas
   };
 }
 
-export function ydbRootCli(profile: ResolvedLocalYdbProfile, args: string[], description: string): CommandSpec {
-  const endpoint = `grpc://localhost:${profile.ports.staticGrpc}`;
+export function waitForYdbCli(profile: ResolvedLocalYdbProfile, args: string[], database: string, description: string, options: { root?: boolean } = {}): CommandSpec {
+  const command = options.root
+    ? commandForYdbRootCli(profile, args)
+    : commandForYdbCli(profile, args, database);
+  const retryableErrors = "CLIENT_UNAUTHENTICATED|SCHEME_ERROR|No database found|connection refused|Endpoint list is empty|Could not resolve redirected path|Failed to connect|TRANSPORT_UNAVAILABLE|UNAVAILABLE";
+  return bash([
+    "set -euo pipefail",
+    "tmp=$(mktemp)",
+    "trap 'rm -f \"$tmp\"' EXIT",
+    "for attempt in $(seq 1 30); do",
+    "  rc=0",
+    `  ${command} >"$tmp" 2>&1 || rc=$?`,
+    "  if [ \"$rc\" -eq 0 ]; then",
+    "    cat \"$tmp\"",
+    "    exit 0",
+    "  fi",
+    `  if grep -Eiq '${retryableErrors}' "$tmp"; then`,
+    "    sleep 2",
+    "  else",
+    "    cat \"$tmp\" >&2",
+    "    exit \"$rc\"",
+    "  fi",
+    "done",
+    "cat \"$tmp\" >&2",
+    "exit 1"
+  ].join("\n"), {
+    allowFailure: true,
+    timeoutMs: 120_000,
+    description,
+    redactions: [profile.rootPasswordFile ?? ""]
+  });
+}
+
+function commandForYdbCli(profile: ResolvedLocalYdbProfile, args: string[], database: string): string {
   if (profile.rootPasswordFile) {
-    return passwordPipedDockerExec(profile, `/ydb -e ${shellQuote(endpoint)} -d ${shellQuote(profile.rootDatabase)} --user ${shellQuote(profile.rootUser)} --password-file /tmp/root.password ${args.map(shellQuote).join(" ")}`, description);
+    return commandForPasswordPipedDockerExec(profile, `/ydb -e grpc://localhost:${profile.ports.dynamicGrpc} -d ${shellQuote(database)} --user ${shellQuote(profile.rootUser)} --password-file /tmp/root.password ${args.map(shellQuote).join(" ")}`);
   }
+  return ["docker", "exec", profile.staticContainer, "/ydb", "-e", `grpc://localhost:${profile.ports.dynamicGrpc}`, "-d", database, ...args].map(shellQuote).join(" ");
+}
+
+export function ydbRootCli(profile: ResolvedLocalYdbProfile, args: string[], description: string): CommandSpec {
+  if (profile.rootPasswordFile) {
+    return bash(commandForYdbRootCli(profile, args), {
+      allowFailure: true,
+      description,
+      redactions: [profile.rootPasswordFile]
+    });
+  }
+  const endpoint = `grpc://localhost:${profile.ports.staticGrpc}`;
   return {
     command: "docker",
     args: ["exec", profile.staticContainer, "/ydb", "-e", endpoint, "-d", profile.rootDatabase, ...args],
     allowFailure: true,
     description
   };
+}
+
+function commandForYdbRootCli(profile: ResolvedLocalYdbProfile, args: string[]): string {
+  const endpoint = `grpc://localhost:${profile.ports.staticGrpc}`;
+  if (profile.rootPasswordFile) {
+    return commandForPasswordPipedDockerExec(profile, `/ydb -e ${shellQuote(endpoint)} -d ${shellQuote(profile.rootDatabase)} --user ${shellQuote(profile.rootUser)} --password-file /tmp/root.password ${args.map(shellQuote).join(" ")}`);
+  }
+  return ["docker", "exec", profile.staticContainer, "/ydb", "-e", endpoint, "-d", profile.rootDatabase, ...args].map(shellQuote).join(" ");
 }
 
 export function ydbdAdmin(profile: ResolvedLocalYdbProfile, args: string[], description: string): CommandSpec {

--- a/packages/core/src/operations/scheme.ts
+++ b/packages/core/src/operations/scheme.ts
@@ -1,4 +1,4 @@
-import { ydbCli } from "./commands.js";
+import { ydbCli, ydbRootCli } from "./commands.js";
 import { capText, normalizeMaxOutputBytes } from "./output.js";
 import type { SchemeAction, SchemeOptions, SchemeResponse, ToolkitContext } from "./types.js";
 
@@ -17,12 +17,10 @@ export async function inspectScheme(
   }
   const maxOutputBytes = normalizeMaxOutputBytes(options.maxOutputBytes);
   const args = schemeArgs(action, path, options);
-  const result = await ctx.client.run(ydbCli(
-    ctx.profile,
-    args,
-    ctx.profile.tenantPath,
-    action === "list" ? "List YDB scheme objects" : "Describe YDB scheme object"
-  ));
+  const description = action === "list" ? "List YDB scheme objects" : "Describe YDB scheme object";
+  const result = await ctx.client.run(usesRootDatabase(ctx, path)
+    ? ydbRootCli(ctx.profile, args, description)
+    : ydbCli(ctx.profile, args, ctx.profile.tenantPath, description));
   const stdout = capText(result.stdout, maxOutputBytes);
   const stderr = capText(result.stderr, maxOutputBytes);
 
@@ -40,6 +38,14 @@ export async function inspectScheme(
     stderrTruncated: stderr.truncated,
     maxOutputBytes
   };
+}
+
+function usesRootDatabase(ctx: ToolkitContext, path: string): boolean {
+  const { rootDatabase, tenantPath } = ctx.profile;
+  if (path === tenantPath || path.startsWith(`${tenantPath}/`)) {
+    return false;
+  }
+  return path === rootDatabase || path.startsWith(`${rootDatabase}/`);
 }
 
 function schemeArgs(action: SchemeAction, path: string, options: SchemeOptions): string[] {

--- a/packages/core/src/operations/stack.ts
+++ b/packages/core/src/operations/stack.ts
@@ -5,7 +5,7 @@ import {
   commandForStaticEnsureRun,
   createTenantSpec,
   removeTenantIfPresentSpec,
-  ydbCli,
+  waitForYdbCli,
   ydbRootCli
 } from "./commands.js";
 import { normalizeExpectedYdbResult, runMutating } from "./execution.js";
@@ -26,7 +26,7 @@ export async function bootstrap(ctx: ToolkitContext, options: MutatingOptions = 
     bash("sleep 5", { description: "Wait briefly for tenant creation" }),
     bash(commandForDynamicEnsureRun(ctx.profile), { timeoutMs: 60_000, description: "Start dynamic tenant node" }),
     bash("sleep 5", { description: "Wait briefly for dynamic node startup" }),
-    ydbCli(ctx.profile, ["scheme", "ls", ctx.profile.tenantPath], ctx.profile.tenantPath, "Verify tenant metadata"),
+    waitForYdbCli(ctx.profile, ["scheme", "ls", ctx.profile.tenantPath], ctx.profile.tenantPath, "Wait for tenant metadata"),
     bash(`curl -fsSL ${shellQuote(`${ctx.profile.monitoringBaseUrl}/viewer/json/capabilities?database=${encodeURIComponent(ctx.profile.tenantPath)}`)} >/dev/null || true`, { allowFailure: true, description: "Verify viewer capabilities endpoint" })
   ];
   return runMutating(ctx, {
@@ -166,13 +166,13 @@ export async function destroyStack(ctx: ToolkitContext, options: DestroyStackOpt
   }
 
   const results: CommandResult[] = [];
-  let tenantRemoveSkippedDueToAuthFailure = false;
+  let tenantRemoveSkipped = false;
   for (const [index, spec] of specs.entries()) {
     const result = normalizeExpectedYdbResult(spec, await ctx.client.run(spec));
     results.push(result);
     if (!result.ok) {
-      if (index === 0 && canContinueAfterTenantRemoveFailure(ctx, options, result)) {
-        tenantRemoveSkippedDueToAuthFailure = true;
+      if (index === 0 && canContinueAfterTenantRemoveFailureDuringTeardown(ctx, options, result)) {
+        tenantRemoveSkipped = true;
         continue;
       }
       break;
@@ -180,8 +180,8 @@ export async function destroyStack(ctx: ToolkitContext, options: DestroyStackOpt
   }
 
   return {
-    summary: tenantRemoveSkippedDueToAuthFailure
-      ? `Destroy local-ydb stack for ${ctx.profile.name}. Executed ${results.filter((result) => result.ok).length}/${results.length} commands after continuing past tenant removal auth failure.`
+    summary: tenantRemoveSkipped
+      ? `Destroy local-ydb stack for ${ctx.profile.name}. Executed ${results.filter((result) => result.ok).length}/${results.length} commands after continuing past tenant removal failure during teardown.`
       : `Destroy local-ydb stack for ${ctx.profile.name}. Executed ${results.filter((result) => result.ok).length}/${results.length} commands.`,
     executed: true,
     risk: "high",
@@ -197,7 +197,7 @@ export async function destroyStack(ctx: ToolkitContext, options: DestroyStackOpt
   };
 }
 
-function canContinueAfterTenantRemoveFailure(
+function canContinueAfterTenantRemoveFailureDuringTeardown(
   ctx: ToolkitContext,
   options: DestroyStackOptions,
   result: CommandResult
@@ -207,7 +207,7 @@ function canContinueAfterTenantRemoveFailure(
     return false;
   }
   const output = `${result.stdout}\n${result.stderr}`;
-  return /UNAUTHORIZED|Invalid password|Access denied|login denied|too many failed password attempts|CLIENT_UNAUTHENTICATED/i.test(output);
+  return /UNAUTHORIZED|Invalid password|Access denied|login denied|too many failed password attempts|CLIENT_UNAUTHENTICATED|connection refused|Endpoint list is empty|Could not resolve redirected path|Failed to connect|TRANSPORT_UNAVAILABLE|No such container/i.test(output);
 }
 
 export async function restartStack(ctx: ToolkitContext, options: MutatingOptions = {}) {

--- a/packages/core/src/operations/storage.ts
+++ b/packages/core/src/operations/storage.ts
@@ -292,7 +292,7 @@ export async function cleanupStorage(ctx: ToolkitContext, options: MutatingOptio
     assertSafeCleanupTarget(volume);
   }
   const specs = [
-    ...volumes.map((volume) => bash(`if docker volume inspect ${shellQuote(volume)} >/dev/null 2>&1; then docker volume rm ${shellQuote(volume)}; fi`)),
+    ...volumes.map((volume) => removeVolumeIfPresentSpec(volume)),
     ...paths.map((path) => bash(`rm -rf -- ${shellQuote(path)} || sudo -n rm -rf -- ${shellQuote(path)}`))
   ];
   return runMutating(ctx, {
@@ -302,6 +302,38 @@ export async function cleanupStorage(ctx: ToolkitContext, options: MutatingOptio
     rollback: ["No automatic rollback after deletion; restore from backups/dumps."],
     verification: ["local_ydb_storage_leftovers no longer reports the removed targets"]
   }, options);
+}
+
+function removeVolumeIfPresentSpec(volume: string) {
+  return bash([
+    "set -euo pipefail",
+    "tmp=$(mktemp)",
+    "trap 'rm -f \"$tmp\"' EXIT",
+    "inspect_rc=0",
+    `docker volume inspect ${shellQuote(volume)} >"$tmp" 2>&1 || inspect_rc=$?`,
+    "if [ \"$inspect_rc\" -eq 0 ]; then",
+    "  rm_rc=0",
+    `  docker volume rm ${shellQuote(volume)} >"$tmp" 2>&1 || rm_rc=$?`,
+    "  if [ \"$rm_rc\" -eq 0 ]; then",
+    "    cat \"$tmp\"",
+    "    exit 0",
+    "  elif grep -Eiq 'no such volume' \"$tmp\"; then",
+    "    cat \"$tmp\"",
+    "    exit 0",
+    "  else",
+    "    cat \"$tmp\" >&2",
+    "    exit \"$rm_rc\"",
+    "  fi",
+    "elif grep -Eiq 'no such volume' \"$tmp\"; then",
+    "  cat \"$tmp\"",
+    "  exit 0",
+    "else",
+    "  cat \"$tmp\" >&2",
+    "  exit \"$inspect_rc\"",
+    "fi"
+  ].join("\n"), {
+    description: `Remove Docker volume ${volume} if present`
+  });
 }
 
 async function readTargetStoragePool(ctx: ToolkitContext, poolName?: string): Promise<ResolvedStoragePoolSummary> {

--- a/packages/core/src/operations/storage.ts
+++ b/packages/core/src/operations/storage.ts
@@ -10,7 +10,7 @@ import {
 import { sanitizeTenantName } from "../validation.js";
 import { applyAuthHardening, prepareAuthConfig, writeDynamicNodeAuthConfig } from "./auth-operations.js";
 import { inventory } from "./checks.js";
-import { ydbCli, ydbdAdmin } from "./commands.js";
+import { waitForYdbCli, ydbCli, ydbdAdmin } from "./commands.js";
 import { addDynamicNodes } from "./dynamic-nodes.js";
 import { runMutating } from "./execution.js";
 import { assertPositiveInteger, assertSafeCleanupTarget, extraDynamicNodeTarget } from "./helpers.js";
@@ -272,11 +272,11 @@ export async function reduceStorageGroups(
     return reduceStorageGroupsResponse(pool, targetNumGroups, dumpName, authReapplyPlanned, extraDynamicNodes, observedNumGroups, plannedCommands, rollback, verification, results);
   }
 
-  results.push(await finalCtx.client.run(ydbCli(
+  results.push(await finalCtx.client.run(waitForYdbCli(
     finalCtx.profile,
     ["scheme", "ls", finalCtx.profile.tenantPath],
     finalCtx.profile.tenantPath,
-    "Verify tenant metadata"
+    "Wait for tenant metadata"
   )));
 
   return reduceStorageGroupsResponse(pool, targetNumGroups, dumpName, authReapplyPlanned, extraDynamicNodes, observedNumGroups, plannedCommands, rollback, verification, results);
@@ -292,7 +292,7 @@ export async function cleanupStorage(ctx: ToolkitContext, options: MutatingOptio
     assertSafeCleanupTarget(volume);
   }
   const specs = [
-    ...volumes.map((volume) => bash(`docker volume rm ${shellQuote(volume)}`)),
+    ...volumes.map((volume) => bash(`if docker volume inspect ${shellQuote(volume)} >/dev/null 2>&1; then docker volume rm ${shellQuote(volume)}; fi`)),
     ...paths.map((path) => bash(`rm -rf -- ${shellQuote(path)} || sudo -n rm -rf -- ${shellQuote(path)}`))
   ];
   return runMutating(ctx, {

--- a/packages/core/test/commands.test.ts
+++ b/packages/core/test/commands.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { ShellCommandExecutor, shellQuote } from "../src/index.js";
+import { waitForCommand } from "../src/operations/commands.js";
+import { ConfigSchema, resolveProfile } from "../src/validation.js";
+
+function createTempDir(): { path: string; cleanup: () => void } {
+  const path = mkdtempSync(join(tmpdir(), "local-ydb-wait-for-command-"));
+  return {
+    path,
+    cleanup: () => rmSync(path, { recursive: true, force: true })
+  };
+}
+
+describe("waitForCommand", () => {
+  it("retries retryable failures until a later attempt succeeds", async () => {
+    const tempDir = createTempDir();
+    try {
+      const counterFile = join(tempDir.path, "counter");
+      const command = [
+        `count=$(cat ${shellQuote(counterFile)} 2>/dev/null || printf 0)`,
+        "count=$((count + 1))",
+        `printf '%s' \"$count\" > ${shellQuote(counterFile)}`,
+        "if [ \"$count\" -lt 3 ]; then",
+        "  printf '%s\\n' 'Status: UNAVAILABLE' >&2",
+        "  exit 7",
+        "fi",
+        "printf '%s\\n' ready"
+      ].join("\n");
+      const spec = waitForCommand(command, "Retry until ready", "Status:[[:space:]]*UNAVAILABLE", {
+        maxAttempts: 3,
+        retryDelaySeconds: 0,
+        timeoutMs: 5_000
+      });
+
+      const executor = new ShellCommandExecutor();
+      const profile = resolveProfile(ConfigSchema.parse({}));
+      const result = await executor.run(profile, spec);
+
+      expect(result.ok).toBe(true);
+      expect(result.stdout).toContain("ready");
+      expect(readFileSync(counterFile, "utf8")).toBe("3");
+    } finally {
+      tempDir.cleanup();
+    }
+  });
+
+  it("returns immediately on a non-retryable failure", async () => {
+    const tempDir = createTempDir();
+    try {
+      const counterFile = join(tempDir.path, "counter");
+      const command = [
+        `count=$(cat ${shellQuote(counterFile)} 2>/dev/null || printf 0)`,
+        "count=$((count + 1))",
+        `printf '%s' \"$count\" > ${shellQuote(counterFile)}`,
+        "printf '%s\\n' 'fatal parse error' >&2",
+        "exit 2"
+      ].join("\n");
+      const spec = waitForCommand(command, "Fail fast", "Status:[[:space:]]*UNAVAILABLE", {
+        maxAttempts: 3,
+        retryDelaySeconds: 0,
+        timeoutMs: 5_000
+      });
+
+      const executor = new ShellCommandExecutor();
+      const profile = resolveProfile(ConfigSchema.parse({}));
+      const result = await executor.run(profile, spec);
+
+      expect(result.ok).toBe(false);
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("fatal parse error");
+      expect(readFileSync(counterFile, "utf8")).toBe("1");
+    } finally {
+      tempDir.cleanup();
+    }
+  });
+
+  it("preserves the last exit code after retry exhaustion", async () => {
+    const tempDir = createTempDir();
+    try {
+      const counterFile = join(tempDir.path, "counter");
+      const command = [
+        `count=$(cat ${shellQuote(counterFile)} 2>/dev/null || printf 0)`,
+        "count=$((count + 1))",
+        `printf '%s' \"$count\" > ${shellQuote(counterFile)}`,
+        "printf '%s\\n' 'Status: UNAVAILABLE' >&2",
+        "exit 7"
+      ].join("\n");
+      const spec = waitForCommand(command, "Exhaust retries", "Status:[[:space:]]*UNAVAILABLE", {
+        maxAttempts: 3,
+        retryDelaySeconds: 0,
+        timeoutMs: 5_000
+      });
+
+      const executor = new ShellCommandExecutor();
+      const profile = resolveProfile(ConfigSchema.parse({}));
+      const result = await executor.run(profile, spec);
+
+      expect(result.ok).toBe(false);
+      expect(result.exitCode).toBe(7);
+      expect(result.stderr).toContain("Status: UNAVAILABLE");
+      expect(readFileSync(counterFile, "utf8")).toBe("3");
+    } finally {
+      tempDir.cleanup();
+    }
+  });
+});

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1000,8 +1000,66 @@ describe("mutating operations", () => {
 
     const response = await destroyStack(ctx, { confirm: true });
     expect(response.executed).toBe(true);
-    expect(response.summary).toContain("continuing past tenant removal auth failure");
+    expect(response.summary).toContain("continuing past tenant removal failure during teardown");
     expect(response.results?.[0]?.ok).toBe(false);
+    expect(response.results?.some((result) => result.command.includes("docker volume rm ydb-local-data"))).toBe(true);
+  });
+
+  it("continues docker teardown when tenant removal cannot reach the static gRPC endpoint", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({
+      profiles: {
+        default: {
+          dynamicContainer: "ydb-dyn-example",
+          staticContainer: "ydb-local",
+          network: "ydb-net",
+          volume: "ydb-local-data"
+        }
+      }
+    }));
+    executor.run = async (_profile, spec) => {
+      const command = executor.display(_profile, spec);
+      executor.commands.push(command);
+      if (command.includes("docker ps -a --format")) {
+        return {
+          command,
+          exitCode: 0,
+          stdout: [
+            JSON.stringify({ Names: "ydb-dyn-example" }),
+            JSON.stringify({ Names: "ydb-local" })
+          ].join("\n"),
+          stderr: "",
+          ok: true,
+          timedOut: false
+        };
+      }
+      if (command.includes("docker volume ls")) {
+        return { command, exitCode: 0, stdout: "ydb-local-data\n", stderr: "", ok: true, timedOut: false };
+      }
+      if (command.includes("admin database /local/example remove --force")) {
+        return {
+          command,
+          exitCode: 1,
+          stdout: "",
+          stderr: "Status: UNAVAILABLE\nEndpoint list is empty: connection refused\n",
+          ok: false,
+          timedOut: false
+        };
+      }
+      return {
+        command,
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        ok: true,
+        timedOut: false
+      };
+    };
+
+    const response = await destroyStack(ctx, { confirm: true });
+    expect(response.executed).toBe(true);
+    expect(response.results?.[0]?.ok).toBe(false);
+    expect(response.results?.some((result) => result.command.includes("docker rm -f ydb-local"))).toBe(true);
     expect(response.results?.some((result) => result.command.includes("docker volume rm ydb-local-data"))).toBe(true);
   });
 
@@ -1131,6 +1189,7 @@ describe("mutating operations", () => {
     expect(response.plannedCommands[0]).toContain("/tmp/local-ydb/config.auth.yaml");
     expect(response.plannedCommands.join("\n")).not.toContain("S3cr3t! rotate me");
     expect(response.plannedCommands.some((command) => command.includes("ALTER USER root PASSWORD"))).toBe(true);
+    expect(response.plannedCommands[0]).toContain("last_error=$(mktemp)");
     expect(response.plannedCommands[1]).toContain("target=$(docker exec ydb-local sh -lc");
     expect(response.plannedCommands[1]).toContain("/ydb_data/kikimr_configs/config.yaml");
     expect(response.plannedCommands[1]).toContain("docker exec ydb-local cat \"$target\"");
@@ -1145,6 +1204,16 @@ describe("mutating operations", () => {
     expect(response.executed).toBe(false);
     expect(response.plannedCommands[0]).toContain("rm -rf -- /tmp/local-ydb-dump/mcp-smoke");
     expect(response.plannedCommands[0]).toContain("sudo -n rm -rf -- /tmp/local-ydb-dump/mcp-smoke");
+  });
+
+  it("skips absent cleanup volumes but fails if an existing volume cannot be removed", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+    const response = await cleanupStorage(ctx, { volumes: ["local-ydb-toolkit-mcp-cleanup-smoke"] });
+    expect(response.executed).toBe(false);
+    expect(response.plannedCommands[0]).toContain("docker volume inspect local-ydb-toolkit-mcp-cleanup-smoke");
+    expect(response.plannedCommands[0]).toContain("then docker volume rm local-ydb-toolkit-mcp-cleanup-smoke");
+    expect(response.plannedCommands[0]).not.toContain("docker volume rm local-ydb-toolkit-mcp-cleanup-smoke || true");
   });
 
   it("prepares a hardened auth config and root password file from the running static config", async () => {

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1212,7 +1212,8 @@ describe("mutating operations", () => {
     const response = await cleanupStorage(ctx, { volumes: ["local-ydb-toolkit-mcp-cleanup-smoke"] });
     expect(response.executed).toBe(false);
     expect(response.plannedCommands[0]).toContain("docker volume inspect local-ydb-toolkit-mcp-cleanup-smoke");
-    expect(response.plannedCommands[0]).toContain("then docker volume rm local-ydb-toolkit-mcp-cleanup-smoke");
+    expect(response.plannedCommands[0]).toContain("docker volume rm local-ydb-toolkit-mcp-cleanup-smoke");
+    expect(response.plannedCommands[0]).toContain("no such volume");
     expect(response.plannedCommands[0]).not.toContain("docker volume rm local-ydb-toolkit-mcp-cleanup-smoke || true");
   });
 

--- a/packages/core/test/scheme.test.ts
+++ b/packages/core/test/scheme.test.ts
@@ -108,6 +108,37 @@ describe("scheme inspection", () => {
     expect(response.command).toContain("scheme describe /local/example/users --stats");
   });
 
+  it("uses the root database endpoint for root database paths", async () => {
+    const executor = new RecordingExecutor(".sys\n");
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+
+    const response = await inspectScheme(ctx, {
+      path: "/local"
+    });
+
+    expect(response).toMatchObject({
+      ok: true,
+      path: "/local",
+      stdout: ".sys\n"
+    });
+    expect(response.command).toContain("scheme ls /local");
+    expect(response.command).toContain("-e grpc://localhost:2136");
+    expect(response.command).toContain("-d /local");
+    expect(response.command).not.toContain("-d /local/example");
+  });
+
+  it("uses the root database endpoint for non-tenant children of the root database", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+
+    const response = await inspectScheme(ctx, {
+      path: "/local/other"
+    });
+
+    expect(response.command).toContain("scheme ls /local/other");
+    expect(response.command).toContain("-d /local");
+  });
+
   it("rejects unsupported flag combinations", async () => {
     const ctx = createContext(undefined, new RecordingExecutor(), ConfigSchema.parse({}));
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the local-ydb startup lifecycle by replacing one-shot `ydbCli` calls with a new `waitForCommand`/`waitForYdbCli` retry loop that handles transient gRPC readiness errors, adds idempotent Docker volume removal via `removeVolumeIfPresentSpec`, routes `inspectScheme` to the correct static or dynamic endpoint based on path prefix, and widens the teardown skip-condition to cover connectivity failures in addition to auth failures.

- `waitForCommand` is a new exported shell-script generator that retries a command against a configurable error pattern, preserving the last exit code after exhaustion, and is exercised by three new unit tests covering success, fast-fail, and exhaustion scenarios.
- `cleanupStorage` replaces bare `docker volume rm` with an inspect-then-rm script that handles TOCTOU \"no such volume\" races idempotently while still surfacing genuine Docker failures.
- `inspectScheme` now routes paths under `rootDatabase` to `ydbRootCli` (static gRPC port) and paths under `tenantPath` to `ydbCli` (dynamic gRPC port), with the routing logic covered by two new scheme tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changed paths are additive lifecycle-readiness hardening with good test coverage.

The retry loop, idempotent volume removal, and scheme routing logic are all well-contained and backed by new unit tests. The two observations are cosmetic edge cases that do not affect any current caller.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/operations/commands.ts | Introduces `waitForCommand` and `waitForYdbCli`; refactors `ydbCli`/`ydbRootCli` to delegate to extracted `commandForYdb*` helpers. Minor: `rc` can be unbound if `maxAttempts` is 0 with `set -u` active. |
| packages/core/src/operations/scheme.ts | Adds `usesRootDatabase` routing logic; correctly prefers the tenant check before the root-database check to handle overlapping prefixes. |
| packages/core/src/operations/storage.ts | Replaces bare `docker volume rm` with idempotent `removeVolumeIfPresentSpec`; switches tenant-metadata check to `waitForYdbCli`. |
| packages/core/src/operations/stack.ts | Replaces one-shot `ydbCli` with `waitForYdbCli` in bootstrap; widens teardown skip-condition to network connectivity errors and `No such container`. |
| packages/core/src/operations/auth-operations.ts | Adds post-auth-hardening `waitForYdbCli` readiness probe; improves `setRootPassword` diagnostics by capturing command output to `last_error` instead of `/dev/null`. |
| packages/core/test/commands.test.ts | New test file covering retry-success, fast-fail, and exhaustion paths for `waitForCommand`. |
| packages/core/test/operations.test.ts | Adds tests for connectivity-based teardown skip, `removeVolumeIfPresentSpec`, and `last_error` temp-file allocation in `setRootPassword`. |
| packages/core/test/scheme.test.ts | Adds tests verifying root-database endpoint routing for root paths and non-tenant children. |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22astandrik%2Flocal-ydb-toolkit%22%20on%20the%20existing%20branch%20%22codex%2Ffix-local-ydb-mcp-lifecycle-readiness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-local-ydb-mcp-lifecycle-readiness%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcore%2Fsrc%2Foperations%2Fcommands.ts%3A281-288%0AIf%20%60maxAttempts%60%20is%20passed%20as%20%600%60%2C%20%60seq%201%200%60%20produces%20no%20output%20and%20the%20loop%20body%20never%20executes%2C%20leaving%20%60rc%60%20unbound.%20With%20%60set%20-u%60%20active%2C%20%60exit%20%22%24rc%22%60%20then%20aborts%20with%20an%20%22unbound%20variable%22%20error%20instead%20of%20a%20clean%20exit.%20Initializing%20%60rc%60%20before%20the%20loop%20makes%20the%20edge%20case%20safe%20and%20also%20makes%20the%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20const%20maxAttempts%20%3D%20options.maxAttempts%20%3F%3F%2030%3B%0A%20%20const%20retryDelaySeconds%20%3D%20options.retryDelaySeconds%20%3F%3F%202%3B%0A%20%20return%20bash%28%5B%0A%20%20%20%20%22set%20-euo%20pipefail%22%2C%0A%20%20%20%20%22tmp%3D%24%28mktemp%29%22%2C%0A%20%20%20%20%22trap%20'rm%20-f%20%5C%22%24tmp%5C%22'%20EXIT%22%2C%0A%20%20%20%20%22rc%3D0%22%2C%0A%20%20%20%20%60for%20attempt%20in%20%24%28seq%201%20%24%7BmaxAttempts%7D%29%3B%20do%60%2C%0A%20%20%20%20%22%20%20rc%3D0%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fcore%2Fsrc%2Foperations%2Fauth-operations.ts%3A262%0A%60last_error%60%20is%20written%20with%20%60%3E%60%20%28truncate%29%2C%20so%20each%20%60rotate_with_password_file%60%20call%20silently%20overwrites%20the%20previous%20attempt's%20output.%20If%20the%20first%20attempt%20fails%20with%20the%20most%20informative%20diagnostic%20%28e.g.%2C%20a%20real%20authentication%20error%29%20and%20later%20attempts%20produce%20an%20empty%20or%20generic%20message%2C%20that%20original%20error%20is%20lost.%20Using%20%60%3E%3E%60%20%28append%29%20would%20preserve%20the%20full%20failure%20trail.%0A%0A%60%60%60suggestion%0A%20%20cat%20%22%24file%22%20%7C%20docker%20exec%20-i%20%24%7BshellQuote%28ctx.profile.staticContainer%29%7D%20bash%20-lc%20%24%7BshellQuote%28%60umask%20077%3B%20cat%20%3E%2Ftmp%2Froot.password%3B%20%2Fydb%20-e%20grpc%3A%2F%2Flocalhost%3A%24%7Bctx.profile.ports.dynamicGrpc%7D%20-d%20%24%7BshellQuote%28ctx.profile.tenantPath%29%7D%20--user%20%24%7BshellQuote%28ctx.profile.rootUser%29%7D%20--password-file%20%2Ftmp%2Froot.password%20yql%20-s%20%22ALTER%20USER%20%24%7Bctx.profile.rootUser%7D%20PASSWORD%20'%24%7BescapedPassword%7D'%3B%22%3B%20rc%3D%24%3F%3B%20rm%20-f%20%2Ftmp%2Froot.password%3B%20exit%20%24rc%60%29%7D%20%3E%3E%22%24last_error%22%202%3E%261%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fcore%2Fsrc%2Foperations%2Fcommands.ts%3A281-288%0AIf%20%60maxAttempts%60%20is%20passed%20as%20%600%60%2C%20%60seq%201%200%60%20produces%20no%20output%20and%20the%20loop%20body%20never%20executes%2C%20leaving%20%60rc%60%20unbound.%20With%20%60set%20-u%60%20active%2C%20%60exit%20%22%24rc%22%60%20then%20aborts%20with%20an%20%22unbound%20variable%22%20error%20instead%20of%20a%20clean%20exit.%20Initializing%20%60rc%60%20before%20the%20loop%20makes%20the%20edge%20case%20safe%20and%20also%20makes%20the%20intent%20clearer.%0A%0A%60%60%60suggestion%0A%20%20const%20maxAttempts%20%3D%20options.maxAttempts%20%3F%3F%2030%3B%0A%20%20const%20retryDelaySeconds%20%3D%20options.retryDelaySeconds%20%3F%3F%202%3B%0A%20%20return%20bash%28%5B%0A%20%20%20%20%22set%20-euo%20pipefail%22%2C%0A%20%20%20%20%22tmp%3D%24%28mktemp%29%22%2C%0A%20%20%20%20%22trap%20'rm%20-f%20%5C%22%24tmp%5C%22'%20EXIT%22%2C%0A%20%20%20%20%22rc%3D0%22%2C%0A%20%20%20%20%60for%20attempt%20in%20%24%28seq%201%20%24%7BmaxAttempts%7D%29%3B%20do%60%2C%0A%20%20%20%20%22%20%20rc%3D0%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fcore%2Fsrc%2Foperations%2Fauth-operations.ts%3A262%0A%60last_error%60%20is%20written%20with%20%60%3E%60%20%28truncate%29%2C%20so%20each%20%60rotate_with_password_file%60%20call%20silently%20overwrites%20the%20previous%20attempt's%20output.%20If%20the%20first%20attempt%20fails%20with%20the%20most%20informative%20diagnostic%20%28e.g.%2C%20a%20real%20authentication%20error%29%20and%20later%20attempts%20produce%20an%20empty%20or%20generic%20message%2C%20that%20original%20error%20is%20lost.%20Using%20%60%3E%3E%60%20%28append%29%20would%20preserve%20the%20full%20failure%20trail.%0A%0A%60%60%60suggestion%0A%20%20cat%20%22%24file%22%20%7C%20docker%20exec%20-i%20%24%7BshellQuote%28ctx.profile.staticContainer%29%7D%20bash%20-lc%20%24%7BshellQuote%28%60umask%20077%3B%20cat%20%3E%2Ftmp%2Froot.password%3B%20%2Fydb%20-e%20grpc%3A%2F%2Flocalhost%3A%24%7Bctx.profile.ports.dynamicGrpc%7D%20-d%20%24%7BshellQuote%28ctx.profile.tenantPath%29%7D%20--user%20%24%7BshellQuote%28ctx.profile.rootUser%29%7D%20--password-file%20%2Ftmp%2Froot.password%20yql%20-s%20%22ALTER%20USER%20%24%7Bctx.profile.rootUser%7D%20PASSWORD%20'%24%7BescapedPassword%7D'%3B%22%3B%20rc%3D%24%3F%3B%20rm%20-f%20%2Ftmp%2Froot.password%3B%20exit%20%24rc%60%29%7D%20%3E%3E%22%24last_error%22%202%3E%261%0A%60%60%60%0A%0A&repo=astandrik%2Flocal-ydb-toolkit&pr=54&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/core/src/operations/commands.ts:281-288
If `maxAttempts` is passed as `0`, `seq 1 0` produces no output and the loop body never executes, leaving `rc` unbound. With `set -u` active, `exit "$rc"` then aborts with an "unbound variable" error instead of a clean exit. Initializing `rc` before the loop makes the edge case safe and also makes the intent clearer.

```suggestion
  const maxAttempts = options.maxAttempts ?? 30;
  const retryDelaySeconds = options.retryDelaySeconds ?? 2;
  return bash([
    "set -euo pipefail",
    "tmp=$(mktemp)",
    "trap 'rm -f \"$tmp\"' EXIT",
    "rc=0",
    `for attempt in $(seq 1 ${maxAttempts}); do`,
    "  rc=0",
```

### Issue 2 of 2
packages/core/src/operations/auth-operations.ts:262
`last_error` is written with `>` (truncate), so each `rotate_with_password_file` call silently overwrites the previous attempt's output. If the first attempt fails with the most informative diagnostic (e.g., a real authentication error) and later attempts produce an empty or generic message, that original error is lost. Using `>>` (append) would preserve the full failure trail.

```suggestion
  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`umask 077; cat >/tmp/root.password; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file /tmp/root.password yql -s "ALTER USER ${ctx.profile.rootUser} PASSWORD '${escapedPassword}';"; rc=$?; rm -f /tmp/root.password; exit $rc`)} >>"$last_error" 2>&1
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(core): address readiness and cleanup..."](https://github.com/astandrik/local-ydb-toolkit/commit/d645d17d3fa087c76d52c9285abd03e0eb7b6a9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32600882)</sub>

<!-- /greptile_comment -->