### PR TITLE
fix(local-ydb): fix root password rotation

### DIFF
--- a/MCP_TOOL_TEST_SCENARIOS.md
+++ b/MCP_TOOL_TEST_SCENARIOS.md
@@ -505,11 +505,14 @@ Expected:
 - the generated host auth config and `root.password` file are updated after the runtime password change
 - post-change anonymous `viewer/json/whoami` should still return `401`
 - authenticated tenant checks should work with the new password
+- empty passwords are an upstream YDB capability, but this MCP tool requires a non-empty `password` argument
+- if the cluster config defines `auth_config.password_complexity`, password rotation can fail until the supplied value matches that policy
 
 Avoid:
 
 - storing the password directly in committed config
 - changing the password on a profile that lacks `authConfigPath` or `rootPasswordFile`
+- assuming every punctuation mark is portable across builds; prefer letters, digits, and documented YDB special characters `!@#$%^&*()_+{}|<>?=` unless the target image has already been rehearsed with a broader set
 
 ## Scenario 11: Add Extra Dynamic Nodes
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Use it only when the caller needs `/local/<tenant>`, GraphShard, tenant storage 
 
 `local_ydb_set_root_password` rotates the runtime `root` password with `ALTER USER`, then updates the configured host-side `config.auth.yaml` and `root.password` files to match. The password value is redacted from the planned command text.
 
+Upstream YDB defaults to no password complexity requirements: even an empty password is accepted unless the cluster config defines `auth_config.password_complexity`. This toolkit's password-rotation tool still requires a non-empty `password` argument, and the selected YDB deployment may reject values that violate its configured policy. Official YDB docs describe the built-in special-character set as `!@#$%^&*()_+{}|<>?=`.
+
 `local_ydb_destroy_stack` tears down a profile end to end: it removes tenant metadata when the static node is reachable, removes extra and primary dynamic nodes, removes the static node, removes the Docker network, and removes the Docker volume for volume-backed profiles. Deleting bind-mounted data, auth artifacts, and dump directories is opt-in through explicit flags because those host paths may be shared.
 
 ## Publishing

--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -61,7 +61,7 @@ function waitForAuthenticatedTenantStatusSpec(ctx: ToolkitContext) {
   }
 
   const withPassword = (innerCommand: string) => {
-    const script = `umask 077; cat >/tmp/root.password; ${innerCommand}; rc=$?; rm -f /tmp/root.password; exit $rc`;
+    const script = `password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX); umask 077; cat >"$password_file"; trap 'rm -f "$password_file"' EXIT; ${innerCommand.replaceAll("/tmp/root.password", '"$password_file"')}`;
     return `cat ${shellQuote(rootPasswordFile)} | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(script)}`;
   };
 
@@ -236,6 +236,16 @@ export async function setRootPassword(
       ["Provide password and rerun."]
     );
   }
+  if (/[\r\n]/.test(password)) {
+    return planOnly(
+      ctx,
+      "Set root password does not support passwords containing carriage returns or newlines.",
+      "high",
+      [],
+      ["No changes."],
+      ["Provide a password without carriage returns or newlines and rerun."]
+    );
+  }
   if (!configHostPath || !rootPasswordFile) {
     return planOnly(
       ctx,
@@ -276,10 +286,13 @@ export async function setRootPassword(
     `rotate_with_password_file() {
   local file="$1"
   [ -f "$file" ] || return 1
-  query_container=$(docker exec ${shellQuote(ctx.profile.staticContainer)} mktemp /tmp/local-ydb-toolkit-password-rotate-XXXXXX.yql)
-  docker cp "$query_host" ${shellQuote(`${ctx.profile.staticContainer}:`)}"$query_container"
+  query_container=$(docker exec ${shellQuote(ctx.profile.staticContainer)} mktemp /tmp/local-ydb-toolkit-password-rotate-XXXXXX.yql) || return $?
+  if ! docker cp "$query_host" ${shellQuote(`${ctx.profile.staticContainer}:`)}"$query_container"; then
+    cleanup_query_container
+    return 1
+  fi
   set +e
-  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`query_file="$1"; umask 077; cat >/tmp/root.password; trap 'rm -f /tmp/root.password "$query_file"' EXIT; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file /tmp/root.password yql -f "$query_file"`)} _ "$query_container" >"$last_error" 2>&1
+  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`query_file="$1"; password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX); umask 077; cat >"$password_file"; trap 'rm -f "$password_file" "$query_file"' EXIT; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file "$password_file" yql -f "$query_file"`)} _ "$query_container" >"$last_error" 2>&1
   rc=$?
   set -e
   cleanup_query_container
@@ -310,17 +323,19 @@ export async function setRootPassword(
 
   const syncHostSpec = bash([
     "set -euo pipefail",
-    "password=$(cat)",
+    "password_host=$(mktemp)",
+    "trap 'rm -f \"$password_host\"' EXIT",
+    "cat > \"$password_host\"",
     `install -d -m 0700 ${shellQuote(dirname(configHostPath))}`,
     `install -d -m 0700 ${shellQuote(dirname(rootPasswordFile))}`,
     `if [ -f ${shellQuote(configHostPath)} ]; then cp ${shellQuote(configHostPath)} ${shellQuote(backupConfig)}; fi`,
     `if [ -f ${shellQuote(rootPasswordFile)} ]; then cp ${shellQuote(rootPasswordFile)} ${shellQuote(backupPassword)}; fi`,
     "cfg_tmp=$(mktemp)",
-    "trap 'rm -f \"$cfg_tmp\"' EXIT",
+    "trap 'rm -f \"$cfg_tmp\" \"$password_host\"' EXIT",
     `target=$(${targetCommand})`,
     `docker exec ${shellQuote(ctx.profile.staticContainer)} cat "$target" > "$cfg_tmp"`,
     [
-      "LOCAL_YDB_NEW_PASSWORD=\"$password\" ruby -ryaml -e",
+      "ruby -ryaml -e",
       shellQuote([
         "config = YAML.load_file(ARGV[0])",
         "domains = config.fetch(\"domains_config\")",
@@ -333,7 +348,7 @@ export async function setRootPassword(
         "security[\"register_dynamic_node_allowed_sids\"] = allowed_sids",
         "root = Array(security[\"default_users\"]).find { |user| user[\"name\"] == \"root\" }",
         "raise \"root password not found in security_config.default_users\" unless root",
-        "password = ENV.fetch(\"LOCAL_YDB_NEW_PASSWORD\")",
+        "password = File.binread(ARGV[5])",
         "root[\"password\"] = password",
         "File.write(ARGV[1], YAML.dump(config))",
         "File.chmod(0600, ARGV[1])",
@@ -344,7 +359,8 @@ export async function setRootPassword(
       shellQuote(configHostPath),
       shellQuote(sid),
       shellQuote(rootPasswordFile),
-      shellQuote(rootSid)
+      shellQuote(rootSid),
+      "\"$password_host\""
     ].join(" ")
   ].join("\n"), {
     stdin: password,

--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -250,18 +250,40 @@ export async function setRootPassword(
   const backupConfig = `${configHostPath}.before-local-ydb-toolkit-password-rotate`;
   const backupPassword = `${rootPasswordFile}.before-local-ydb-toolkit-password-rotate`;
   const escapedPassword = password.replace(/'/g, "''");
-  const rubyPasswordLiteral = `'${password.replace(/\\/g, "\\\\").replace(/'/g, "\\\\'")}'`;
-  const rotateQueryPath = "/tmp/local-ydb-toolkit-password-rotate.yql";
-  const rotateQuery = `ALTER USER ${ctx.profile.rootUser} PASSWORD '${escapedPassword}';`;
   const rotateSpec = bash([
     "set -euo pipefail",
     "candidate=$(mktemp)",
     "last_error=$(mktemp)",
-    "trap 'rm -f \"$candidate\" \"$last_error\"' EXIT",
+    "query_host=$(mktemp)",
+    "query_container=",
+    `cleanup_query_container() {
+  if [ -n "$query_container" ]; then
+    docker exec ${shellQuote(ctx.profile.staticContainer)} rm -f "$query_container" >/dev/null 2>&1 || true
+    query_container=
+  fi
+}`,
+    "trap 'rm -f \"$candidate\" \"$last_error\" \"$query_host\"; cleanup_query_container' EXIT",
+    [
+      "ruby -e",
+      shellQuote([
+        "password = STDIN.read",
+        "password = password.sub(/\\n\\z/, \"\")",
+        "sql_escaped = password.gsub(\"'\", \"''\")",
+        `File.write(ARGV[0], "ALTER USER ${ctx.profile.rootUser} PASSWORD '#{sql_escaped}';\\n")`
+      ].join("; ")),
+      "\"$query_host\""
+    ].join(" "),
     `rotate_with_password_file() {
   local file="$1"
   [ -f "$file" ] || return 1
-  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`umask 077; cat >/tmp/root.password; printf '%s\\n' ${shellQuote(rotateQuery)} > ${shellQuote(rotateQueryPath)}; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file /tmp/root.password yql -f ${shellQuote(rotateQueryPath)}; rc=$?; rm -f /tmp/root.password ${shellQuote(rotateQueryPath)}; exit $rc`)} >"$last_error" 2>&1
+  query_container=$(docker exec ${shellQuote(ctx.profile.staticContainer)} mktemp /tmp/local-ydb-toolkit-password-rotate-XXXXXX.yql)
+  docker cp "$query_host" ${shellQuote(`${ctx.profile.staticContainer}:`)}"$query_container"
+  set +e
+  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`query_file="$1"; umask 077; cat >/tmp/root.password; trap 'rm -f /tmp/root.password "$query_file"' EXIT; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file /tmp/root.password yql -f "$query_file"`)} _ "$query_container" >"$last_error" 2>&1
+  rc=$?
+  set -e
+  cleanup_query_container
+  return "$rc"
 }`,
     `extract_password_from_config() {
   local file="$1"
@@ -281,12 +303,14 @@ export async function setRootPassword(
     "cat \"$last_error\" >&2",
     "exit 1"
   ].join("\n"), {
+    stdin: password,
     redactions: [password, escapedPassword, backupPassword, backupConfig],
     description: `Alter runtime root password for ${ctx.profile.name}`
   });
 
   const syncHostSpec = bash([
     "set -euo pipefail",
+    "password=$(cat)",
     `install -d -m 0700 ${shellQuote(dirname(configHostPath))}`,
     `install -d -m 0700 ${shellQuote(dirname(rootPasswordFile))}`,
     `if [ -f ${shellQuote(configHostPath)} ]; then cp ${shellQuote(configHostPath)} ${shellQuote(backupConfig)}; fi`,
@@ -296,7 +320,7 @@ export async function setRootPassword(
     `target=$(${targetCommand})`,
     `docker exec ${shellQuote(ctx.profile.staticContainer)} cat "$target" > "$cfg_tmp"`,
     [
-      "ruby -ryaml -e",
+      "LOCAL_YDB_NEW_PASSWORD=\"$password\" ruby -ryaml -e",
       shellQuote([
         "config = YAML.load_file(ARGV[0])",
         "domains = config.fetch(\"domains_config\")",
@@ -309,7 +333,7 @@ export async function setRootPassword(
         "security[\"register_dynamic_node_allowed_sids\"] = allowed_sids",
         "root = Array(security[\"default_users\"]).find { |user| user[\"name\"] == \"root\" }",
         "raise \"root password not found in security_config.default_users\" unless root",
-        `password = ${rubyPasswordLiteral}`,
+        "password = ENV.fetch(\"LOCAL_YDB_NEW_PASSWORD\")",
         "root[\"password\"] = password",
         "File.write(ARGV[1], YAML.dump(config))",
         "File.chmod(0600, ARGV[1])",
@@ -323,6 +347,7 @@ export async function setRootPassword(
       shellQuote(rootSid)
     ].join(" ")
   ].join("\n"), {
+    stdin: password,
     redactions: [password, escapedPassword, backupPassword, backupConfig],
     description: "Sync host auth config and root password file with the new root password"
   });

--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -61,7 +61,7 @@ function waitForAuthenticatedTenantStatusSpec(ctx: ToolkitContext) {
   }
 
   const withPassword = (innerCommand: string) => {
-    const script = `password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX); umask 077; cat >"$password_file"; trap 'rm -f "$password_file"' EXIT; ${innerCommand.replaceAll("/tmp/root.password", '"$password_file"')}`;
+    const script = `umask 077; password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX); trap 'rm -f "$password_file"' EXIT; cat >"$password_file"; ${innerCommand.replaceAll("/tmp/root.password", '"$password_file"')}`;
     return `cat ${shellQuote(rootPasswordFile)} | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(script)}`;
   };
 
@@ -297,7 +297,7 @@ export async function setRootPassword(
     return 1
   fi
   set +e
-  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`query_file="$1"; password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX); umask 077; cat >"$password_file"; trap 'rm -f "$password_file" "$query_file"' EXIT; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file "$password_file" yql -f "$query_file"`)} _ "$query_container" >"$last_error" 2>&1
+  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`query_file="$1"; umask 077; password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX); trap 'rm -f "$password_file" "$query_file"' EXIT; cat >"$password_file"; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file "$password_file" yql -f "$query_file"`)} _ "$query_container" >"$last_error" 2>&1
   rc=$?
   set -e
   cleanup_query_container

--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -251,6 +251,8 @@ export async function setRootPassword(
   const backupPassword = `${rootPasswordFile}.before-local-ydb-toolkit-password-rotate`;
   const escapedPassword = password.replace(/'/g, "''");
   const rubyPasswordLiteral = `'${password.replace(/\\/g, "\\\\").replace(/'/g, "\\\\'")}'`;
+  const rotateQueryPath = "/tmp/local-ydb-toolkit-password-rotate.yql";
+  const rotateQuery = `ALTER USER ${ctx.profile.rootUser} PASSWORD '${escapedPassword}';`;
   const rotateSpec = bash([
     "set -euo pipefail",
     "candidate=$(mktemp)",
@@ -259,7 +261,7 @@ export async function setRootPassword(
     `rotate_with_password_file() {
   local file="$1"
   [ -f "$file" ] || return 1
-  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`umask 077; cat >/tmp/root.password; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file /tmp/root.password yql -s "ALTER USER ${ctx.profile.rootUser} PASSWORD '${escapedPassword}';"; rc=$?; rm -f /tmp/root.password; exit $rc`)} >"$last_error" 2>&1
+  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`umask 077; cat >/tmp/root.password; printf '%s\\n' ${shellQuote(rotateQuery)} > ${shellQuote(rotateQueryPath)}; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file /tmp/root.password yql -f ${shellQuote(rotateQueryPath)}; rc=$?; rm -f /tmp/root.password ${shellQuote(rotateQueryPath)}; exit $rc`)} >"$last_error" 2>&1
 }`,
     `extract_password_from_config() {
   local file="$1"

--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -61,7 +61,7 @@ function waitForAuthenticatedTenantStatusSpec(ctx: ToolkitContext) {
   }
 
   const withPassword = (innerCommand: string) => {
-    const script = `umask 077; password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX); trap 'rm -f "$password_file"' EXIT; cat >"$password_file"; ${innerCommand.replaceAll("/tmp/root.password", '"$password_file"')}`;
+    const script = `set -e; umask 077; password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX); trap 'rc=$?; rm -f "$password_file"; trap - EXIT HUP INT TERM; exit "$rc"' EXIT HUP INT TERM; cat >"$password_file"; ${innerCommand.replaceAll("/tmp/root.password", '"$password_file"')}`;
     return `cat ${shellQuote(rootPasswordFile)} | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(script)}`;
   };
 
@@ -297,7 +297,7 @@ export async function setRootPassword(
     return 1
   fi
   set +e
-  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`query_file="$1"; umask 077; password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX); trap 'rm -f "$password_file" "$query_file"' EXIT; cat >"$password_file"; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file "$password_file" yql -f "$query_file"`)} _ "$query_container" >"$last_error" 2>&1
+  cat "$file" | docker exec -i ${shellQuote(ctx.profile.staticContainer)} bash -lc ${shellQuote(`set -e; query_file="$1"; umask 077; password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX); trap 'rc=$?; rm -f "$password_file" "$query_file"; trap - EXIT HUP INT TERM; exit "$rc"' EXIT HUP INT TERM; cat >"$password_file"; /ydb -e grpc://localhost:${ctx.profile.ports.dynamicGrpc} -d ${shellQuote(ctx.profile.tenantPath)} --user ${shellQuote(ctx.profile.rootUser)} --password-file "$password_file" yql -f "$query_file"`)} _ "$query_container" >"$last_error" 2>&1
   rc=$?
   set -e
   cleanup_query_container

--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -259,7 +259,7 @@ export async function setRootPassword(
 
   const backupConfig = `${configHostPath}.before-local-ydb-toolkit-password-rotate`;
   const backupPassword = `${rootPasswordFile}.before-local-ydb-toolkit-password-rotate`;
-  const escapedPassword = password.replace(/'/g, "''");
+  const escapedPassword = password.replace(/\\/g, "\\\\").replace(/'/g, "''");
   const rotateSpec = bash([
     "set -euo pipefail",
     "candidate=$(mktemp)",
@@ -272,7 +272,7 @@ export async function setRootPassword(
     query_container=
   fi
 }`,
-    "trap 'rm -f \"$candidate\" \"$last_error\" \"$query_host\"; cleanup_query_container' EXIT",
+    "trap 'rc=$?; rm -f \"$candidate\" \"$last_error\" \"$query_host\"; cleanup_query_container; trap - EXIT HUP INT TERM; exit \"$rc\"' EXIT HUP INT TERM",
     [
       "ruby -e",
       shellQuote([
@@ -282,7 +282,7 @@ export async function setRootPassword(
         "end",
         "password = STDIN.read",
         "user = yql_identifier(ARGV.fetch(1))",
-        "sql_escaped = password.gsub(\"'\", \"''\")",
+        "sql_escaped = password.gsub(\"\\\\\") { \"\\\\\\\\\" }.gsub(\"'\", \"''\")",
         "File.write(ARGV[0], \"ALTER USER #{user} PASSWORD '#{sql_escaped}';\\n\")"
       ].join("; ")),
       "\"$query_host\"",
@@ -329,14 +329,14 @@ export async function setRootPassword(
   const syncHostSpec = bash([
     "set -euo pipefail",
     "password_host=$(mktemp)",
-    "trap 'rm -f \"$password_host\"' EXIT",
+    "trap 'rc=$?; rm -f \"$password_host\"; trap - EXIT HUP INT TERM; exit \"$rc\"' EXIT HUP INT TERM",
     "cat > \"$password_host\"",
     `install -d -m 0700 ${shellQuote(dirname(configHostPath))}`,
     `install -d -m 0700 ${shellQuote(dirname(rootPasswordFile))}`,
     `if [ -f ${shellQuote(configHostPath)} ]; then cp ${shellQuote(configHostPath)} ${shellQuote(backupConfig)}; fi`,
     `if [ -f ${shellQuote(rootPasswordFile)} ]; then cp ${shellQuote(rootPasswordFile)} ${shellQuote(backupPassword)}; fi`,
     "cfg_tmp=$(mktemp)",
-    "trap 'rm -f \"$cfg_tmp\" \"$password_host\"' EXIT",
+    "trap 'rc=$?; rm -f \"$cfg_tmp\" \"$password_host\"; trap - EXIT HUP INT TERM; exit \"$rc\"' EXIT HUP INT TERM",
     `target=$(${targetCommand})`,
     `docker exec ${shellQuote(ctx.profile.staticContainer)} cat "$target" > "$cfg_tmp"`,
     [
@@ -353,7 +353,7 @@ export async function setRootPassword(
         "security[\"register_dynamic_node_allowed_sids\"] = allowed_sids",
         "root = Array(security[\"default_users\"]).find { |user| user[\"name\"] == \"root\" }",
         "raise \"root password not found in security_config.default_users\" unless root",
-        "password = File.binread(ARGV[5])",
+        "password = File.read(ARGV[5], mode: \"r:UTF-8\")",
         "root[\"password\"] = password",
         "File.write(ARGV[1], YAML.dump(config))",
         "File.chmod(0600, ARGV[1])",

--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -276,12 +276,17 @@ export async function setRootPassword(
     [
       "ruby -e",
       shellQuote([
+        "def yql_identifier(value)",
+        "escaped = value.gsub(\"\\\\\") { \"\\\\\\\\\" }.gsub(\"`\") { \"\\\\`\" }",
+        "\"`#{escaped}`\"",
+        "end",
         "password = STDIN.read",
-        "password = password.sub(/\\n\\z/, \"\")",
+        "user = yql_identifier(ARGV.fetch(1))",
         "sql_escaped = password.gsub(\"'\", \"''\")",
-        `File.write(ARGV[0], "ALTER USER ${ctx.profile.rootUser} PASSWORD '#{sql_escaped}';\\n")`
+        "File.write(ARGV[0], \"ALTER USER #{user} PASSWORD '#{sql_escaped}';\\n\")"
       ].join("; ")),
-      "\"$query_host\""
+      "\"$query_host\"",
+      shellQuote(ctx.profile.rootUser)
     ].join(" "),
     `rotate_with_password_file() {
   local file="$1"

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1289,10 +1289,13 @@ describe("mutating operations", () => {
 
   it("plans root password rotation without exposing the password", async () => {
     const executor = new RecordingExecutor();
+    const rawCommands: string[] = [];
     executor.display = (profile, spec) => {
       const password = "S3cr3t! rotate me";
       const escapedPassword = password.replace(/'/g, "''");
-      return redactCommand(commandToShell(spec), [
+      const rawCommand = commandToShell(spec);
+      rawCommands.push(rawCommand);
+      return redactCommand(rawCommand, [
         password,
         escapedPassword,
         profile.rootPasswordFile ?? "",
@@ -1317,6 +1320,12 @@ describe("mutating operations", () => {
     expect(response.plannedCommands.some((command) => command.includes("mktemp /tmp/local-ydb-toolkit-password-rotate-XXXXXX.yql"))).toBe(true);
     expect(response.plannedCommands.some((command) => command.includes("docker cp \"$query_host\""))).toBe(true);
     expect(response.plannedCommands.some((command) => command.includes("yql -f"))).toBe(true);
+    const rotationPasswordFile = rawCommands[0].indexOf("password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX)");
+    const rotationTrap = rawCommands[0].indexOf("trap", rotationPasswordFile);
+    const rotationPasswordWrite = rawCommands[0].indexOf("cat >\"$password_file\"", rotationPasswordFile);
+    expect(rotationPasswordFile).toBeGreaterThan(-1);
+    expect(rotationTrap).toBeGreaterThan(rotationPasswordFile);
+    expect(rotationPasswordWrite).toBeGreaterThan(rotationTrap);
     expect(response.plannedCommands.some((command) => command.includes("yql -s \"ALTER USER root PASSWORD"))).toBe(false);
     expect(response.plannedCommands[0]).toContain("last_error=$(mktemp)");
     expect(response.plannedCommands[1]).toContain("target=$(docker exec ydb-local sh -lc");
@@ -1324,6 +1333,13 @@ describe("mutating operations", () => {
     expect(response.plannedCommands[1]).toContain("docker exec ydb-local cat \"$target\"");
     expect(response.plannedCommands.filter((command) => command.includes("docker restart ydb-local")).length).toBe(0);
     expect(response.plannedCommands.some((command) => command.includes("viewer/json/whoami"))).toBe(true);
+    const verifyCommand = rawCommands[2] ?? "";
+    const verifyPasswordFile = verifyCommand.indexOf("password_file=$(mktemp /tmp/local-ydb-toolkit-root-password-XXXXXX)");
+    const verifyTrap = verifyCommand.indexOf("trap", verifyPasswordFile);
+    const verifyPasswordWrite = verifyCommand.indexOf("cat >\"$password_file\"", verifyPasswordFile);
+    expect(verifyPasswordFile).toBeGreaterThan(-1);
+    expect(verifyTrap).toBeGreaterThan(verifyPasswordFile);
+    expect(verifyPasswordWrite).toBeGreaterThan(verifyTrap);
   });
 
   it("keeps quoted and escaped passwords out of the planned rotation command", async () => {

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1313,9 +1313,10 @@ describe("mutating operations", () => {
     expect(response.executed).toBe(false);
     expect(response.plannedCommands[0]).toContain("/tmp/local-ydb/config.auth.yaml");
     expect(response.plannedCommands.join("\n")).not.toContain("S3cr3t! rotate me");
-    expect(response.plannedCommands.some((command) => command.includes("ALTER USER root PASSWORD"))).toBe(true);
+    expect(response.plannedCommands.some((command) => command.includes("query_host=$(mktemp)"))).toBe(true);
+    expect(response.plannedCommands.some((command) => command.includes("mktemp /tmp/local-ydb-toolkit-password-rotate-XXXXXX.yql"))).toBe(true);
+    expect(response.plannedCommands.some((command) => command.includes("docker cp \"$query_host\""))).toBe(true);
     expect(response.plannedCommands.some((command) => command.includes("yql -f"))).toBe(true);
-    expect(response.plannedCommands.some((command) => command.includes("local-ydb-toolkit-password-rotate.yql"))).toBe(true);
     expect(response.plannedCommands.some((command) => command.includes("yql -s \"ALTER USER root PASSWORD"))).toBe(false);
     expect(response.plannedCommands[0]).toContain("last_error=$(mktemp)");
     expect(response.plannedCommands[1]).toContain("target=$(docker exec ydb-local sh -lc");
@@ -1323,6 +1324,42 @@ describe("mutating operations", () => {
     expect(response.plannedCommands[1]).toContain("docker exec ydb-local cat \"$target\"");
     expect(response.plannedCommands.filter((command) => command.includes("docker restart ydb-local")).length).toBe(0);
     expect(response.plannedCommands.some((command) => command.includes("viewer/json/whoami"))).toBe(true);
+  });
+
+  it("keeps quoted and escaped passwords out of the planned rotation command", async () => {
+    const executor = new RecordingExecutor();
+    const password = "pa'ss\\word";
+    executor.display = (profile, spec) => {
+      const escapedPassword = password.replace(/'/g, "''");
+      return redactCommand(commandToShell(spec), [
+        password,
+        escapedPassword,
+        shellQuote(password),
+        shellQuote(escapedPassword),
+        profile.rootPasswordFile ?? "",
+        `${profile.rootPasswordFile ?? ""}.before-local-ydb-toolkit-password-rotate`,
+        `${profile.authConfigPath ?? ""}.before-local-ydb-toolkit-password-rotate`
+      ]);
+    };
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({
+      profiles: {
+        default: {
+          authConfigPath: "/tmp/local-ydb/config.auth.yaml",
+          dynamicNodeAuthTokenFile: "/tmp/local-ydb/auth.pb",
+          rootPasswordFile: "/tmp/local-ydb/root.password"
+        }
+      }
+    }));
+
+    const response = await setRootPassword(ctx, { password });
+    const plan = response.plannedCommands.join("\n");
+    const escapedPassword = password.replace(/'/g, "''");
+
+    expect(plan).not.toContain(password);
+    expect(plan).not.toContain(shellQuote(password));
+    expect(plan).not.toContain(shellQuote(escapedPassword));
+    expect(plan).toContain("docker cp \"$query_host\"");
+    expect(plan).toContain("cleanup_query_container");
   });
 
   it("falls back to sudo when removing root-owned cleanup paths", async () => {

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1362,6 +1362,25 @@ describe("mutating operations", () => {
     expect(plan).toContain("cleanup_query_container");
   });
 
+  it("rejects passwords containing carriage returns or newlines", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({
+      profiles: {
+        default: {
+          authConfigPath: "/tmp/local-ydb/config.auth.yaml",
+          dynamicNodeAuthTokenFile: "/tmp/local-ydb/auth.pb",
+          rootPasswordFile: "/tmp/local-ydb/root.password"
+        }
+      }
+    }));
+
+    const response = await setRootPassword(ctx, { password: "line1\nline2" });
+
+    expect(response.executed).toBe(false);
+    expect(response.summary).toContain("does not support passwords containing carriage returns or newlines");
+    expect(response.plannedCommands).toEqual([]);
+  });
+
   it("falls back to sudo when removing root-owned cleanup paths", async () => {
     const executor = new RecordingExecutor();
     const ctx = createContext(undefined, executor, ConfigSchema.parse({}));

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1289,9 +1289,11 @@ describe("mutating operations", () => {
 
   it("plans root password rotation without exposing the password", async () => {
     const executor = new RecordingExecutor();
+    const password = "S3cr3t! rotate me";
     const rawCommands: string[] = [];
+    const capturedSpecs: CommandSpec[] = [];
     executor.display = (profile, spec) => {
-      const password = "S3cr3t! rotate me";
+      capturedSpecs.push(spec);
       const escapedPassword = password.replace(/\\/g, "\\\\").replace(/'/g, "''");
       const rawCommand = commandToShell(spec);
       rawCommands.push(rawCommand);
@@ -1312,8 +1314,12 @@ describe("mutating operations", () => {
         }
       }
     }));
-    const response = await setRootPassword(ctx, { password: "S3cr3t! rotate me" });
+    const response = await setRootPassword(ctx, { password });
     expect(response.executed).toBe(false);
+    expect(capturedSpecs[0].description).toContain("Alter runtime root password");
+    expect(capturedSpecs[0].stdin).toBe(password);
+    expect(capturedSpecs[1].description).toBe("Sync host auth config and root password file with the new root password");
+    expect(capturedSpecs[1].stdin).toBe(password);
     expect(response.plannedCommands[0]).toContain("/tmp/local-ydb/config.auth.yaml");
     expect(response.plannedCommands.join("\n")).not.toContain("S3cr3t! rotate me");
     expect(response.plannedCommands.some((command) => command.includes("query_host=$(mktemp)"))).toBe(true);

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1362,7 +1362,32 @@ describe("mutating operations", () => {
     expect(plan).toContain("cleanup_query_container");
   });
 
-  it("rejects passwords containing carriage returns or newlines", async () => {
+  it("passes the root user to the rotation query generator as data", async () => {
+    const executor = new RecordingExecutor();
+    const rootUser = "root`; raise 'boom'; #";
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({
+      profiles: {
+        default: {
+          authConfigPath: "/tmp/local-ydb/config.auth.yaml",
+          dynamicNodeAuthTokenFile: "/tmp/local-ydb/auth.pb",
+          rootPasswordFile: "/tmp/local-ydb/root.password",
+          rootUser
+        }
+      }
+    }));
+
+    const response = await setRootPassword(ctx, { password: "S3cr3t!" });
+    const plan = response.plannedCommands.join("\n");
+
+    expect(plan).toContain("ARGV.fetch(1)");
+    expect(plan).toContain("yql_identifier");
+    expect(plan).not.toContain(`ALTER USER ${rootUser}`);
+  });
+
+  it.each([
+    ["carriage return", "line1\rline2"],
+    ["newline", "line1\nline2"]
+  ])("rejects passwords containing %s", async (_label, password) => {
     const executor = new RecordingExecutor();
     const ctx = createContext(undefined, executor, ConfigSchema.parse({
       profiles: {
@@ -1374,7 +1399,7 @@ describe("mutating operations", () => {
       }
     }));
 
-    const response = await setRootPassword(ctx, { password: "line1\nline2" });
+    const response = await setRootPassword(ctx, { password });
 
     expect(response.executed).toBe(false);
     expect(response.summary).toContain("does not support passwords containing carriage returns or newlines");

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1292,7 +1292,7 @@ describe("mutating operations", () => {
     const rawCommands: string[] = [];
     executor.display = (profile, spec) => {
       const password = "S3cr3t! rotate me";
-      const escapedPassword = password.replace(/'/g, "''");
+      const escapedPassword = password.replace(/\\/g, "\\\\").replace(/'/g, "''");
       const rawCommand = commandToShell(spec);
       rawCommands.push(rawCommand);
       return redactCommand(rawCommand, [
@@ -1328,11 +1328,17 @@ describe("mutating operations", () => {
     expect(rotationPasswordWrite).toBeGreaterThan(rotationTrap);
     expect(rawCommands[0]).toContain("EXIT HUP INT TERM");
     expect(rawCommands[0]).toContain("set -e; query_file=");
+    expect(rawCommands[0]).toContain("rm -f \"$candidate\" \"$last_error\" \"$query_host\"; cleanup_query_container; trap - EXIT HUP INT TERM");
+    expect(rawCommands[0]).toContain("sql_escaped = password.gsub");
+    expect(rawCommands[0]).toContain("{ \"\\\\\\\\\" }.gsub");
     expect(response.plannedCommands.some((command) => command.includes("yql -s \"ALTER USER root PASSWORD"))).toBe(false);
     expect(response.plannedCommands[0]).toContain("last_error=$(mktemp)");
     expect(response.plannedCommands[1]).toContain("target=$(docker exec ydb-local sh -lc");
     expect(response.plannedCommands[1]).toContain("/ydb_data/kikimr_configs/config.yaml");
     expect(response.plannedCommands[1]).toContain("docker exec ydb-local cat \"$target\"");
+    expect(rawCommands[1]).toContain("rm -f \"$password_host\"; trap - EXIT HUP INT TERM");
+    expect(rawCommands[1]).toContain("rm -f \"$cfg_tmp\" \"$password_host\"; trap - EXIT HUP INT TERM");
+    expect(rawCommands[1]).toContain("File.read(ARGV[5], mode: \"r:UTF-8\")");
     expect(response.plannedCommands.filter((command) => command.includes("docker restart ydb-local")).length).toBe(0);
     expect(response.plannedCommands.some((command) => command.includes("viewer/json/whoami"))).toBe(true);
     const verifyCommand = rawCommands[2] ?? "";
@@ -1350,7 +1356,7 @@ describe("mutating operations", () => {
     const executor = new RecordingExecutor();
     const password = "pa'ss\\word";
     executor.display = (profile, spec) => {
-      const escapedPassword = password.replace(/'/g, "''");
+      const escapedPassword = password.replace(/\\/g, "\\\\").replace(/'/g, "''");
       return redactCommand(commandToShell(spec), [
         password,
         escapedPassword,
@@ -1373,7 +1379,7 @@ describe("mutating operations", () => {
 
     const response = await setRootPassword(ctx, { password });
     const plan = response.plannedCommands.join("\n");
-    const escapedPassword = password.replace(/'/g, "''");
+    const escapedPassword = password.replace(/\\/g, "\\\\").replace(/'/g, "''");
 
     expect(plan).not.toContain(password);
     expect(plan).not.toContain(shellQuote(password));

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1314,6 +1314,9 @@ describe("mutating operations", () => {
     expect(response.plannedCommands[0]).toContain("/tmp/local-ydb/config.auth.yaml");
     expect(response.plannedCommands.join("\n")).not.toContain("S3cr3t! rotate me");
     expect(response.plannedCommands.some((command) => command.includes("ALTER USER root PASSWORD"))).toBe(true);
+    expect(response.plannedCommands.some((command) => command.includes("yql -f"))).toBe(true);
+    expect(response.plannedCommands.some((command) => command.includes("local-ydb-toolkit-password-rotate.yql"))).toBe(true);
+    expect(response.plannedCommands.some((command) => command.includes("yql -s \"ALTER USER root PASSWORD"))).toBe(false);
     expect(response.plannedCommands[0]).toContain("last_error=$(mktemp)");
     expect(response.plannedCommands[1]).toContain("target=$(docker exec ydb-local sh -lc");
     expect(response.plannedCommands[1]).toContain("/ydb_data/kikimr_configs/config.yaml");

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1326,6 +1326,8 @@ describe("mutating operations", () => {
     expect(rotationPasswordFile).toBeGreaterThan(-1);
     expect(rotationTrap).toBeGreaterThan(rotationPasswordFile);
     expect(rotationPasswordWrite).toBeGreaterThan(rotationTrap);
+    expect(rawCommands[0]).toContain("EXIT HUP INT TERM");
+    expect(rawCommands[0]).toContain("set -e; query_file=");
     expect(response.plannedCommands.some((command) => command.includes("yql -s \"ALTER USER root PASSWORD"))).toBe(false);
     expect(response.plannedCommands[0]).toContain("last_error=$(mktemp)");
     expect(response.plannedCommands[1]).toContain("target=$(docker exec ydb-local sh -lc");
@@ -1340,6 +1342,8 @@ describe("mutating operations", () => {
     expect(verifyPasswordFile).toBeGreaterThan(-1);
     expect(verifyTrap).toBeGreaterThan(verifyPasswordFile);
     expect(verifyPasswordWrite).toBeGreaterThan(verifyTrap);
+    expect(verifyCommand).toContain("EXIT HUP INT TERM");
+    expect(verifyCommand).toContain("set -e; umask 077");
   });
 
   it("keeps quoted and escaped passwords out of the planned rotation command", async () => {

--- a/packages/mcp-server/src/tools/args.ts
+++ b/packages/mcp-server/src/tools/args.ts
@@ -98,7 +98,7 @@ export const DynamicAuthConfigArgs = MutatingArgs.extend({
 });
 
 export const SetRootPasswordArgs = MutatingArgs.extend({
-  password: z.string().min(1),
+  password: z.string().min(1).regex(/^[^\r\n]+$/, "password must not contain carriage returns or newlines"),
 });
 
 export const CleanupArgs = MutatingArgs.extend({

--- a/packages/mcp-server/src/tools/args.ts
+++ b/packages/mcp-server/src/tools/args.ts
@@ -98,7 +98,7 @@ export const DynamicAuthConfigArgs = MutatingArgs.extend({
 });
 
 export const SetRootPasswordArgs = MutatingArgs.extend({
-  password: z.string().min(1).regex(/^[^\r\n]+$/, "password must not contain carriage returns or newlines"),
+  password: z.string().min(1).refine((value) => !/[\r\n]/.test(value), "password must not contain carriage returns or newlines"),
 });
 
 export const CleanupArgs = MutatingArgs.extend({

--- a/packages/mcp-server/src/tools/input-schemas.ts
+++ b/packages/mcp-server/src/tools/input-schemas.ts
@@ -571,7 +571,7 @@ export function setRootPasswordSchema(): Tool["inputSchema"] {
       password: {
         type: "string",
         description:
-          "New root password to apply to the runtime root user and then persist into the host auth config and root password file.",
+          "New non-empty root password to apply to the runtime root user and then persist into the host auth config and root password file. YDB defaults to no password complexity requirements, but the selected cluster may still reject the value when auth_config.password_complexity is configured.",
       },
     },
     additionalProperties: false,

--- a/packages/mcp-server/src/tools/input-schemas.ts
+++ b/packages/mcp-server/src/tools/input-schemas.ts
@@ -570,6 +570,7 @@ export function setRootPasswordSchema(): Tool["inputSchema"] {
       },
       password: {
         type: "string",
+        minLength: 1,
         description:
           "New non-empty root password to apply to the runtime root user and then persist into the host auth config and root password file. YDB defaults to no password complexity requirements, but the selected cluster may still reject the value when auth_config.password_complexity is configured.",
       },

--- a/packages/mcp-server/src/tools/input-schemas.ts
+++ b/packages/mcp-server/src/tools/input-schemas.ts
@@ -571,8 +571,9 @@ export function setRootPasswordSchema(): Tool["inputSchema"] {
       password: {
         type: "string",
         minLength: 1,
+        pattern: "^[^\\r\\n]+$",
         description:
-          "New non-empty root password to apply to the runtime root user and then persist into the host auth config and root password file. YDB defaults to no password complexity requirements, but the selected cluster may still reject the value when auth_config.password_complexity is configured.",
+          "New non-empty root password without carriage returns or newlines to apply to the runtime root user and then persist into the host auth config and root password file. YDB defaults to no password complexity requirements, but the selected cluster may still reject the value when auth_config.password_complexity is configured.",
       },
     },
     additionalProperties: false,

--- a/packages/mcp-server/src/tools/input-schemas.ts
+++ b/packages/mcp-server/src/tools/input-schemas.ts
@@ -571,7 +571,7 @@ export function setRootPasswordSchema(): Tool["inputSchema"] {
       password: {
         type: "string",
         minLength: 1,
-        pattern: "^[^\\r\\n]+$",
+        pattern: "^(?!.*[\\r\\n]).+$",
         description:
           "New non-empty root password without carriage returns or newlines to apply to the runtime root user and then persist into the host auth config and root password file. YDB defaults to no password complexity requirements, but the selected cluster may still reject the value when auth_config.password_complexity is configured.",
       },

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -434,7 +434,7 @@ export const toolDefinitions = [
     group: "auth",
     name: "local_ydb_set_root_password",
     description:
-      "Rotate the runtime root password with ALTER USER and sync the host auth config and root password file to match.",
+      "Rotate the runtime root password with ALTER USER and sync the host auth config and root password file to match. YDB may reject passwords that violate auth_config.password_complexity; this tool requires a non-empty password value.",
     inputSchema: setRootPasswordSchema(),
     handler: withContext(SetRootPasswordArgs, (context, parsed) =>
       setRootPassword(context, parsed),

--- a/packages/mcp-server/test/tools.test.ts
+++ b/packages/mcp-server/test/tools.test.ts
@@ -408,6 +408,34 @@ describe("mcp tools", () => {
     });
   });
 
+  it("exposes root password constraints in the tool schema", () => {
+    const tool = localYdbTools.find((candidate) => candidate.name === "local_ydb_set_root_password");
+    const password = tool?.inputSchema.properties?.password as { pattern?: string } | undefined;
+    const pattern = new RegExp(password?.pattern ?? "");
+
+    expect(tool?.inputSchema.required).toContain("password");
+    expect(password).toMatchObject({
+      type: "string",
+      minLength: 1,
+      pattern: "^(?!.*[\\r\\n]).+$"
+    });
+    expect(pattern.test("S3cr3t!")).toBe(true);
+    expect(pattern.test("S3cr3t!\n")).toBe(false);
+    expect(pattern.test("S3cr3t!\r")).toBe(false);
+  });
+
+  it("rejects invalid root password arguments through Zod", async () => {
+    await expect(callLocalYdbToolForTest("local_ydb_set_root_password", {
+      password: ""
+    })).rejects.toThrow();
+    await expect(callLocalYdbToolForTest("local_ydb_set_root_password", {
+      password: "line1\nline2"
+    })).rejects.toThrow("password must not contain carriage returns or newlines");
+    await expect(callLocalYdbToolForTest("local_ydb_set_root_password", {
+      password: "line1\rline2"
+    })).rejects.toThrow("password must not contain carriage returns or newlines");
+  });
+
   it("exposes scheme inspection options in the tool schema", () => {
     const tool = localYdbTools.find((candidate) => candidate.name === "local_ydb_scheme");
     expect(tool?.inputSchema.properties?.action).toMatchObject({

--- a/skills/local-ydb/references/auth-hardening.md
+++ b/skills/local-ydb/references/auth-hardening.md
@@ -55,7 +55,7 @@ Clusters can still tighten this through `auth_config.password_complexity`, for e
 Operational guidance for this toolkit:
 
 - `local_ydb_set_root_password` requires a non-empty password value even though upstream YDB can allow an empty password
-- if rotation fails with a password-policy error, inspect the active `security_config.password_complexity` in the generated `config.yaml` before retrying
+- if rotation fails with a password-policy error, inspect the active `auth_config.password_complexity` in the generated `config.yaml` before retrying
 - prefer letters, digits, and documented YDB special characters unless the target build has already been rehearsed with a wider character set
 
 ## Dynamic Node Auth

--- a/skills/local-ydb/references/auth-hardening.md
+++ b/skills/local-ydb/references/auth-hardening.md
@@ -35,6 +35,29 @@ Field-proven default-root behavior on `local-ydb` images:
 
 Because of that split identity, viewer/monitoring/admin/register-dynamic-node ACLs should usually include both `root` and `root@builtin` unless the deployed build proves a different SID mapping.
 
+## Password Policy
+
+Upstream YDB defaults to no password complexity requirements. In the default posture:
+
+- empty passwords are allowed by YDB itself through `PASSWORD NULL` or equivalent SQL
+- existing passwords keep working if a stricter policy is configured later
+- special-character guidance in YDB docs is based on `!@#$%^&*()_+{}|<>?=`
+
+Clusters can still tighten this through `auth_config.password_complexity`, for example:
+
+- `min_length`
+- `min_lower_case_count`
+- `min_upper_case_count`
+- `min_numbers_count`
+- `min_special_chars_count`
+- `special_chars`
+
+Operational guidance for this toolkit:
+
+- `local_ydb_set_root_password` requires a non-empty password value even though upstream YDB can allow an empty password
+- if rotation fails with a password-policy error, inspect the active `security_config.password_complexity` in the generated `config.yaml` before retrying
+- prefer letters, digits, and documented YDB special characters unless the target build has already been rehearsed with a wider character set
+
 ## Dynamic Node Auth
 
 For a mandatory-auth local-ydb dynamic node, `--auth-token-file` is a text protobuf for `NKikimrProto.TAuthConfig`, not a raw access-token file. Two fields matter during startup:

--- a/skills/local-ydb/references/mcp-tool-scenarios.md
+++ b/skills/local-ydb/references/mcp-tool-scenarios.md
@@ -468,11 +468,14 @@ Expected:
 - the generated host auth config and `root.password` file are updated after the runtime password change
 - post-change anonymous `viewer/json/whoami` should still return `401`
 - authenticated tenant checks should work with the new password
+- empty passwords are an upstream YDB capability, but this MCP tool requires a non-empty `password` argument
+- if the cluster config defines `auth_config.password_complexity`, password rotation can fail until the supplied value matches that policy
 
 Avoid:
 
 - storing the password directly in committed config
 - changing the password on a profile that lacks `authConfigPath` or `rootPasswordFile`
+- assuming every punctuation mark is portable across builds; prefer letters, digits, and documented YDB special characters `!@#$%^&*()_+{}|<>?=` unless the target image has already been rehearsed with a broader set
 
 ## Scenario 11: Add Extra Dynamic Nodes
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes several correctness and security issues in the root-password rotation flow: passwords containing backslashes were silently corrupted in the YQL query (only single-quotes were escaped, not backslashes), and the `rootUser` name was interpolated directly into the ALTER USER statement, making it injectable. The fixes pass the username as a data argument to Ruby and introduce a `yql_identifier` helper for safe backtick quoting.

- **Backslash escaping**: both the TypeScript `escapedPassword` (used for redaction) and the Ruby `sql_escaped` builder now double-escape `\` before escaping `'`, closing a silent data-corruption bug for any password containing a backslash.
- **rootUser injection fix**: `rootUser` is now passed as `ARGV.fetch(1)` to the Ruby script and wrapped with `yql_identifier`, which escapes `\` and `` ` `` before quoting; a matching test with a backtick-injected username verifies the fix.
- **Trap hardening**: all `trap` handlers now capture `$?`, extend to `HUP INT TERM`, clear themselves before exiting, and re-emit the original exit code, ensuring temp files are cleaned up on signal and that the caller sees the correct status.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are well-scoped fixes with corresponding tests and no regressions observed.

All changed code paths have matching test coverage, the injection fix is correctly implemented (rootUser passed as data, not interpolated into SQL), the backslash-escaping bug is fixed consistently in both TypeScript and Ruby, and the trap hardening is mechanically correct. No unguarded code paths or dropped state found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/operations/auth-operations.ts | Core auth operation fixes: proper backslash escaping in passwords, rootUser injection prevention via yql_identifier + argv data passing, improved trap signal handling with exit code propagation, and explicit UTF-8 file read. |
| packages/core/test/operations.test.ts | Tests expanded to verify trap ordering, signal handling, escape sequences, rootUser injection safety, and both CR and LF rejection — all aligned with the new implementation. |
| packages/mcp-server/src/tools/args.ts | Password validation switched from `.regex()` to `.refine()`, which is semantically equivalent here but clearer in intent; no functional regression. |
| packages/mcp-server/src/tools/input-schemas.ts | JSON Schema pattern updated to `^(?!.*[\r\n]).+$`, which is stricter than the old `^[^\r\n]+$` (the old pattern could match a string ending with `\n` in ECMAScript where `$` matches before a final newline). |
| packages/mcp-server/test/tools.test.ts | New tests cover the updated schema pattern (CR, LF rejection) and Zod validation path; straightforward and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TS as TypeScript (setRootPassword)
    participant OB as Outer Bash (rotateSpec)
    participant Ruby as Ruby (query generator)
    participant IB as Inner Bash (rotate_with_password_file)
    participant YDB as /ydb CLI (container)
    participant SB as Sync Bash (syncHostSpec)
    participant RubySync as Ruby (config updater)

    TS->>OB: "stdin=newPassword"
    OB->>Ruby: "stdin=newPassword, ARGV[0]=$query_host, ARGV[1]=rootUser"
    Ruby->>Ruby: yql_identifier(rootUser) → backtick-quoted identifier
    Ruby->>Ruby: "sql_escaped = escape backslashes + single quotes"
    Ruby-->>OB: writes ALTER USER `user` PASSWORD '...' to $query_host
    OB->>OB: docker cp $query_host → container:$query_container
    OB->>IB: "stdin=existingPasswordFile, ARGV[1]=$query_container"
    IB->>IB: "cat >"$password_file" (existing password)"
    IB->>YDB: --password-file $password_file yql -f $query_container
    YDB-->>IB: success / error → $last_error
    IB-->>OB: rc
    OB-->>TS: result

    TS->>SB: "stdin=newPassword"
    SB->>SB: "cat >"$password_host" (new password)"
    SB->>RubySync: "ARGV[5]=$password_host (File.read UTF-8)"
    RubySync->>RubySync: update config YAML + write rootPasswordFile
    RubySync-->>SB: done
    SB-->>TS: result
```

<sub>Reviews (8): Last reviewed commit: ["test(local-ydb): assert password rotatio..."](https://github.com/astandrik/local-ydb-toolkit/commit/811ab7a0a33acad20274ef719e7fd233d8e8afb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32624893)</sub>

<!-- /greptile_comment -->