### PR TITLE
fix: mcp scheme flags and redaction

### DIFF
--- a/packages/core/src/api-client.ts
+++ b/packages/core/src/api-client.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { dirname } from "node:path";
 import { redactCommand, redactText } from "./auth.js";
 import type { ResolvedLocalYdbProfile } from "./validation.js";
 
@@ -120,13 +121,26 @@ function sshArgs(profile: ResolvedLocalYdbProfile, remoteCommand: string): strin
 }
 
 function collectRedactions(profile: ResolvedLocalYdbProfile, spec: CommandSpec): string[] {
-  return dedupeRedactions([
+  const profilePathRedactions = pathRedactions(
     profile.authConfigPath,
     profile.dynamicNodeAuthTokenFile,
     profile.rootPasswordFile,
-    profile.ssh?.identityFile,
+    profile.ssh?.identityFile
+  );
+  return dedupeRedactions([
+    ...profilePathRedactions,
     ...(spec.redactions ?? [])
   ]);
+}
+
+function pathRedactions(...values: Array<string | undefined>): string[] {
+  return values.flatMap((value) => {
+    if (!value) {
+      return [];
+    }
+    const parent = dirname(value);
+    return parent === "." || parent === "/" || parent === value ? [value] : [value, parent];
+  });
 }
 
 function dedupeRedactions(values: Array<string | undefined>): string[] {

--- a/packages/core/src/api-client.ts
+++ b/packages/core/src/api-client.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
-import { dirname } from "node:path";
 import { redactCommand, redactText } from "./auth.js";
+import { pathRedactions } from "./redactions.js";
 import type { ResolvedLocalYdbProfile } from "./validation.js";
 
 export interface CommandSpec {
@@ -133,20 +133,18 @@ function collectRedactions(profile: ResolvedLocalYdbProfile, spec: CommandSpec):
   ]);
 }
 
-function pathRedactions(...values: Array<string | undefined>): string[] {
-  return values.flatMap((value) => {
-    if (!value) {
-      return [];
-    }
-    const parent = dirname(value);
-    return parent === "." || parent === "/" || parent === value ? [value] : [value, parent];
-  });
-}
-
 function dedupeRedactions(values: Array<string | undefined>): string[] {
-  return [...new Set(values
-    .filter((value): value is string => Boolean(value))
-    .flatMap((value) => [value, shellQuote(value)]))];
+  const redactions: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values.filter((value): value is string => Boolean(value))) {
+    for (const candidate of [value, shellQuote(value)]) {
+      if (!seen.has(candidate)) {
+        seen.add(candidate);
+        redactions.push(candidate);
+      }
+    }
+  }
+  return redactions.sort((left, right) => right.length - left.length);
 }
 
 function redactCommandSpec(spec: CommandSpec, redactions: string[]): CommandSpec {

--- a/packages/core/src/api-client.ts
+++ b/packages/core/src/api-client.ts
@@ -120,6 +120,8 @@ function sshArgs(profile: ResolvedLocalYdbProfile, remoteCommand: string): strin
 
 function collectRedactions(profile: ResolvedLocalYdbProfile, spec: CommandSpec): string[] {
   return [
+    profile.authConfigPath,
+    profile.dynamicNodeAuthTokenFile,
     profile.rootPasswordFile,
     profile.ssh?.identityFile,
     ...(spec.redactions ?? [])

--- a/packages/core/src/api-client.ts
+++ b/packages/core/src/api-client.ts
@@ -48,11 +48,12 @@ export function bash(script: string, options: Omit<CommandSpec, "command" | "arg
 export class ShellCommandExecutor implements CommandExecutor {
   display(profile: ResolvedLocalYdbProfile, spec: CommandSpec): string {
     const redactions = collectRedactions(profile, spec);
+    const displaySpec = redactCommandSpec(spec, redactions);
     if (profile.mode === "ssh") {
-      const args = sshArgs(profile, commandToShell(spec));
+      const args = sshArgs(profile, commandToShell(displaySpec));
       return redactCommand(["ssh", ...args].map(shellQuote).join(" "), redactions);
     }
-    return redactCommand(commandToShell(spec), redactions);
+    return redactCommand(commandToShell(displaySpec), redactions);
   }
 
   run(profile: ResolvedLocalYdbProfile, spec: CommandSpec): Promise<CommandResult> {
@@ -119,13 +120,27 @@ function sshArgs(profile: ResolvedLocalYdbProfile, remoteCommand: string): strin
 }
 
 function collectRedactions(profile: ResolvedLocalYdbProfile, spec: CommandSpec): string[] {
-  return [
+  return dedupeRedactions([
     profile.authConfigPath,
     profile.dynamicNodeAuthTokenFile,
     profile.rootPasswordFile,
     profile.ssh?.identityFile,
     ...(spec.redactions ?? [])
-  ].filter((value): value is string => Boolean(value));
+  ]);
+}
+
+function dedupeRedactions(values: Array<string | undefined>): string[] {
+  return [...new Set(values
+    .filter((value): value is string => Boolean(value))
+    .flatMap((value) => [value, shellQuote(value)]))];
+}
+
+function redactCommandSpec(spec: CommandSpec, redactions: string[]): CommandSpec {
+  return {
+    ...spec,
+    command: redactText(spec.command, redactions),
+    args: spec.args?.map((arg) => redactText(arg, redactions))
+  };
 }
 
 export interface DockerContainerSummary {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -5,9 +5,7 @@ const SENSITIVE_FLAGS = new Set([
   "--auth-token-file",
   "--access-token",
   "--private-key",
-  "--sa-key-file",
-  "-f",
-  "-i"
+  "--sa-key-file"
 ]);
 
 export function redactText(input: string, extraRedactions: string[] = []): string {
@@ -21,23 +19,80 @@ export function redactText(input: string, extraRedactions: string[] = []): strin
 }
 
 export function redactCommand(command: string, extraRedactions: string[] = []): string {
-  const parts = command.split(/(\s+)/);
+  const parts = splitTopLevelShellParts(command);
   let redactNext = false;
+  let commandName: string | undefined;
   return redactText(parts.map((part) => {
-    if (/^\s+$/.test(part)) {
-      return part;
+    if (!part.isWord) {
+      return part.text;
     }
+    commandName ??= part.text;
     if (redactNext) {
       redactNext = false;
       return "<redacted>";
     }
-    const flag = part.includes("=") ? part.slice(0, part.indexOf("=")) : part;
-    if (SENSITIVE_FLAGS.has(flag)) {
-      if (part.includes("=")) {
+    const flag = part.text.includes("=") ? part.text.slice(0, part.text.indexOf("=")) : part.text;
+    const isSensitiveFlag = SENSITIVE_FLAGS.has(flag) || (commandName === "ssh" && flag === "-i");
+    if (isSensitiveFlag) {
+      if (part.text.includes("=")) {
         return `${flag}=<redacted>`;
       }
       redactNext = true;
     }
-    return part;
+    return part.text;
   }).join(""), extraRedactions);
+}
+
+function splitTopLevelShellParts(input: string): Array<{ text: string; isWord: boolean }> {
+  const parts: Array<{ text: string; isWord: boolean }> = [];
+  let current = "";
+  let whitespace = "";
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let escaped = false;
+
+  function pushWord(): void {
+    if (current) {
+      parts.push({ text: current, isWord: true });
+      current = "";
+    }
+  }
+
+  function pushWhitespace(): void {
+    if (whitespace) {
+      parts.push({ text: whitespace, isWord: false });
+      whitespace = "";
+    }
+  }
+
+  for (const char of input) {
+    if (!inSingleQuote && !inDoubleQuote && /\s/.test(char)) {
+      pushWord();
+      whitespace += char;
+      continue;
+    }
+
+    pushWhitespace();
+    current += char;
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\" && !inSingleQuote) {
+      escaped = true;
+      continue;
+    }
+
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+    } else if (char === "\"" && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+    }
+  }
+
+  pushWord();
+  pushWhitespace();
+  return parts;
 }

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -68,27 +68,21 @@ function redactSensitiveFlagValues(input: string): string {
 function findShellWordEnd(input: string, start: number): number {
   let quote: "'" | "\"" | undefined;
   let escaped = false;
-  let sawUnquoted = false;
 
   for (let index = start; index < input.length; index += 1) {
     const char = input[index];
     if (escaped) {
       escaped = false;
-      sawUnquoted = true;
       continue;
     }
     if (char === "\\" && quote !== "'") {
       escaped = true;
-      sawUnquoted = true;
       continue;
     }
     if (!quote && /\s/.test(char)) {
       return index;
     }
     if (!quote && (char === "'" || char === "\"")) {
-      if (sawUnquoted) {
-        return index;
-      }
       quote = char;
       continue;
     }
@@ -96,7 +90,6 @@ function findShellWordEnd(input: string, start: number): number {
       quote = undefined;
       continue;
     }
-    sawUnquoted = true;
   }
 
   return input.length;

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -32,6 +32,7 @@ const SSH_OPTIONS_WITH_VALUE = new Set([
   "-W",
   "-w"
 ]);
+const OPENSSH_COMMANDS_WITH_IDENTITY_FILE = new Set(["ssh", "scp", "sftp"]);
 
 export function redactText(input: string, extraRedactions: string[] = []): string {
   let output = input;
@@ -57,7 +58,7 @@ export function redactCommand(command: string, extraRedactions: string[] = []): 
       return "<redacted>";
     }
     const flag = part.text.includes("=") ? part.text.slice(0, part.text.indexOf("=")) : part.text;
-    const isSensitiveFlag = SENSITIVE_FLAG_SET.has(flag) || (isSshCommandName(commandName) && flag === "-i");
+    const isSensitiveFlag = SENSITIVE_FLAG_SET.has(flag) || (isOpenSshCommandName(commandName) && flag === "-i");
     if (isSensitiveFlag) {
       if (part.text.includes("=")) {
         return `${flag}=<redacted>`;
@@ -116,14 +117,14 @@ function collectSshIdentityRanges(input: string, start: number, end: number, ran
       break;
     }
     const sshEnd = findSshWordEnd(input, sshStart);
-    if (!isSshCommandName(input.slice(sshStart, sshEnd))) {
+    if (!isOpenSshCommandName(input.slice(sshStart, sshEnd))) {
       cursor = sshEnd;
       continue;
     }
     cursor = sshEnd;
     for (;;) {
       const wordStart = skipShellWhitespace(input, cursor);
-      if (wordStart >= input.length || isShellCommandBoundary(input[wordStart])) {
+      if (wordStart >= end || isShellCommandBoundary(input[wordStart])) {
         break;
       }
       const wordEnd = findShellWordEnd(input, wordStart);
@@ -149,7 +150,11 @@ function collectSshIdentityRanges(input: string, start: number, end: number, ran
       if (!word.startsWith("-") || word === "-") {
         break;
       }
-      if (SSH_OPTIONS_WITH_VALUE.has(word)) {
+      const attachedValueStart = getAttachedSshOptionValueStart(word);
+      if (attachedValueStart !== undefined) {
+        collectSshIdentityRanges(input, wordStart + attachedValueStart, wordEnd, ranges);
+        cursor = wordEnd;
+      } else if (SSH_OPTIONS_WITH_VALUE.has(word)) {
         const valueStart = skipShellWhitespace(input, wordEnd);
         const valueEnd = Math.min(findShellWordEnd(input, valueStart), end);
         collectSshIdentityRanges(input, valueStart, valueEnd, ranges);
@@ -178,8 +183,20 @@ function redactRanges(input: string, ranges: Array<{ start: number; end: number 
   return output + input.slice(cursor);
 }
 
-function isSshCommandName(commandName: string | undefined): boolean {
-  return commandName === "ssh" || commandName?.endsWith("/ssh") === true;
+function getAttachedSshOptionValueStart(word: string): number | undefined {
+  if (word.length <= 2 || !word.startsWith("-") || word.startsWith("--")) {
+    return undefined;
+  }
+  const option = word.slice(0, 2);
+  return SSH_OPTIONS_WITH_VALUE.has(option) ? 2 : undefined;
+}
+
+function isOpenSshCommandName(commandName: string | undefined): boolean {
+  if (!commandName) {
+    return false;
+  }
+  const basename = commandName.slice(commandName.lastIndexOf("/") + 1);
+  return OPENSSH_COMMANDS_WITH_IDENTITY_FILE.has(basename);
 }
 
 function findNextSshWordStart(input: string, start: number): number {
@@ -258,6 +275,7 @@ function findCommandValueEnd(input: string, start: number): number {
 function findShellWordEnd(input: string, start: number): number {
   let quote: "'" | "\"" | undefined;
   let escaped = false;
+  let substitutionDepth = 0;
 
   for (let index = start; index < input.length; index += 1) {
     const char = input[index];
@@ -269,8 +287,17 @@ function findShellWordEnd(input: string, start: number): number {
       escaped = true;
       continue;
     }
-    if (!quote && /\s/.test(char)) {
+    if (!quote && substitutionDepth === 0 && /\s/.test(char)) {
       return index;
+    }
+    if (!quote && isShellSubstitutionStart(input, index)) {
+      substitutionDepth += 1;
+      index += 1;
+      continue;
+    }
+    if (!quote && substitutionDepth > 0 && char === ")") {
+      substitutionDepth -= 1;
+      continue;
     }
     if (!quote && (char === "'" || char === "\"")) {
       quote = char;
@@ -283,6 +310,13 @@ function findShellWordEnd(input: string, start: number): number {
   }
 
   return input.length;
+}
+
+function isShellSubstitutionStart(input: string, index: number): boolean {
+  if (input[index + 1] !== "(") {
+    return false;
+  }
+  return input[index] === "<" || input[index] === ">" || input[index] === "$";
 }
 
 function splitTopLevelShellParts(input: string): Array<{ text: string; isWord: boolean }> {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -9,30 +9,40 @@ const SENSITIVE_FLAGS = [
 ] as const;
 const SENSITIVE_FLAG_SET = new Set<string>(SENSITIVE_FLAGS);
 const SENSITIVE_FLAG_PATTERN = buildSensitiveFlagPattern(SENSITIVE_FLAGS);
-const SSH_OPTIONS_WITH_VALUE = new Set([
-  "-B",
-  "-b",
-  "-c",
-  "-D",
-  "-E",
-  "-e",
-  "-F",
-  "-I",
-  "-J",
-  "-L",
-  "-l",
-  "-m",
-  "-O",
-  "-o",
-  "-P",
-  "-p",
-  "-Q",
-  "-R",
-  "-S",
-  "-W",
-  "-w"
-]);
-const OPENSSH_COMMANDS_WITH_IDENTITY_FILE = new Set(["ssh", "scp", "sftp"]);
+const OPENSSH_COMMAND_OPTIONS_WITH_VALUE = {
+  ssh: new Set([
+    "-B",
+    "-b",
+    "-c",
+    "-D",
+    "-E",
+    "-e",
+    "-F",
+    "-I",
+    "-J",
+    "-L",
+    "-l",
+    "-m",
+    "-O",
+    "-o",
+    "-P",
+    "-p",
+    "-Q",
+    "-R",
+    "-S",
+    "-W",
+    "-w"
+  ]),
+  scp: new Set(["-c", "-D", "-F", "-J", "-l", "-o", "-P", "-S", "-X"]),
+  sftp: new Set(["-B", "-b", "-c", "-D", "-F", "-J", "-l", "-o", "-P", "-R", "-S", "-s", "-X"])
+};
+type OpenSshCommand = keyof typeof OPENSSH_COMMAND_OPTIONS_WITH_VALUE;
+type OpenSshOptionAction =
+  | { kind: "flag" }
+  | { kind: "identity-next" }
+  | { kind: "identity-attached"; valueStart: number }
+  | { kind: "value-next" }
+  | { kind: "value-attached"; valueStart: number };
 
 export function redactText(input: string, extraRedactions: string[] = []): string {
   let output = input;
@@ -58,7 +68,7 @@ export function redactCommand(command: string, extraRedactions: string[] = []): 
       return "<redacted>";
     }
     const flag = part.text.includes("=") ? part.text.slice(0, part.text.indexOf("=")) : part.text;
-    const isSensitiveFlag = SENSITIVE_FLAG_SET.has(flag) || (isOpenSshCommandName(commandName) && flag === "-i");
+    const isSensitiveFlag = SENSITIVE_FLAG_SET.has(flag) || (getOpenSshCommandName(commandName) !== undefined && flag === "-i");
     if (isSensitiveFlag) {
       if (part.text.includes("=")) {
         return `${flag}=<redacted>`;
@@ -117,10 +127,12 @@ function collectSshIdentityRanges(input: string, start: number, end: number, ran
       break;
     }
     const sshEnd = findSshWordEnd(input, sshStart);
-    if (!isOpenSshCommandName(input.slice(sshStart, sshEnd))) {
+    const commandName = getOpenSshCommandName(input.slice(sshStart, sshEnd));
+    if (!commandName) {
       cursor = sshEnd;
       continue;
     }
+    const optionsWithValue = OPENSSH_COMMAND_OPTIONS_WITH_VALUE[commandName];
     cursor = sshEnd;
     for (;;) {
       const wordStart = skipShellWhitespace(input, cursor);
@@ -132,7 +144,11 @@ function collectSshIdentityRanges(input: string, start: number, end: number, ran
       if (word === "--") {
         break;
       }
-      if (word === "-i") {
+      if (!word.startsWith("-") || word === "-") {
+        break;
+      }
+      const optionAction = classifyOpenSshOptionWord(word, optionsWithValue);
+      if (optionAction.kind === "identity-next") {
         const valueStart = skipShellWhitespace(input, wordEnd);
         if (valueStart >= end) {
           break;
@@ -142,19 +158,15 @@ function collectSshIdentityRanges(input: string, start: number, end: number, ran
         cursor = valueEnd;
         continue;
       }
-      if (word.startsWith("-i") && word.length > 2) {
-        ranges.push({ start: wordStart + 2, end: wordEnd });
+      if (optionAction.kind === "identity-attached") {
+        ranges.push({ start: wordStart + optionAction.valueStart, end: wordEnd });
         cursor = wordEnd;
         continue;
       }
-      if (!word.startsWith("-") || word === "-") {
-        break;
-      }
-      const attachedValueStart = getAttachedSshOptionValueStart(word);
-      if (attachedValueStart !== undefined) {
-        collectSshIdentityRanges(input, wordStart + attachedValueStart, wordEnd, ranges);
+      if (optionAction.kind === "value-attached") {
+        collectSshIdentityRanges(input, wordStart + optionAction.valueStart, wordEnd, ranges);
         cursor = wordEnd;
-      } else if (SSH_OPTIONS_WITH_VALUE.has(word)) {
+      } else if (optionAction.kind === "value-next") {
         const valueStart = skipShellWhitespace(input, wordEnd);
         const valueEnd = Math.min(findShellWordEnd(input, valueStart), end);
         collectSshIdentityRanges(input, valueStart, valueEnd, ranges);
@@ -183,20 +195,28 @@ function redactRanges(input: string, ranges: Array<{ start: number; end: number 
   return output + input.slice(cursor);
 }
 
-function getAttachedSshOptionValueStart(word: string): number | undefined {
-  if (word.length <= 2 || !word.startsWith("-") || word.startsWith("--")) {
-    return undefined;
+function classifyOpenSshOptionWord(word: string, optionsWithValue: Set<string>): OpenSshOptionAction {
+  if (word.length < 2 || !word.startsWith("-") || word.startsWith("--")) {
+    return { kind: "flag" };
   }
-  const option = word.slice(0, 2);
-  return SSH_OPTIONS_WITH_VALUE.has(option) ? 2 : undefined;
+  for (let index = 1; index < word.length; index += 1) {
+    const option = `-${word[index]}`;
+    if (option === "-i") {
+      return index === word.length - 1 ? { kind: "identity-next" } : { kind: "identity-attached", valueStart: index + 1 };
+    }
+    if (optionsWithValue.has(option)) {
+      return index === word.length - 1 ? { kind: "value-next" } : { kind: "value-attached", valueStart: index + 1 };
+    }
+  }
+  return { kind: "flag" };
 }
 
-function isOpenSshCommandName(commandName: string | undefined): boolean {
+function getOpenSshCommandName(commandName: string | undefined): OpenSshCommand | undefined {
   if (!commandName) {
-    return false;
+    return undefined;
   }
   const basename = commandName.slice(commandName.lastIndexOf("/") + 1);
-  return OPENSSH_COMMANDS_WITH_IDENTITY_FILE.has(basename);
+  return basename in OPENSSH_COMMAND_OPTIONS_WITH_VALUE ? basename as OpenSshCommand : undefined;
 }
 
 function findNextSshWordStart(input: string, start: number): number {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -9,6 +9,28 @@ const SENSITIVE_FLAGS = [
 ] as const;
 const SENSITIVE_FLAG_SET = new Set<string>(SENSITIVE_FLAGS);
 const SENSITIVE_FLAG_PATTERN = buildSensitiveFlagPattern(SENSITIVE_FLAGS);
+const SSH_COMMAND_PATTERN = /(^|[\s'"`;&|()])ssh(?=$|[\s'"`;&|()])/g;
+const SSH_OPTIONS_WITH_VALUE = new Set([
+  "-b",
+  "-c",
+  "-D",
+  "-E",
+  "-e",
+  "-F",
+  "-I",
+  "-J",
+  "-L",
+  "-l",
+  "-m",
+  "-O",
+  "-o",
+  "-p",
+  "-Q",
+  "-R",
+  "-S",
+  "-W",
+  "-w"
+]);
 
 export function redactText(input: string, extraRedactions: string[] = []): string {
   let output = input;
@@ -43,7 +65,7 @@ export function redactCommand(command: string, extraRedactions: string[] = []): 
     }
     return part.text;
   }).join("");
-  return redactText(redactSensitiveFlagValues(topLevelRedacted), extraRedactions);
+  return redactText(redactSshIdentityValues(redactSensitiveFlagValues(topLevelRedacted)), extraRedactions);
 }
 
 function redactSensitiveFlagValues(input: string): string {
@@ -77,6 +99,62 @@ function buildSensitiveFlagPattern(flags: readonly string[]): RegExp {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
+function redactSshIdentityValues(input: string): string {
+  let output = "";
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  SSH_COMMAND_PATTERN.lastIndex = 0;
+  while ((match = SSH_COMMAND_PATTERN.exec(input)) !== null) {
+    const sshStart = match.index + match[1].length;
+    if (sshStart < lastIndex) {
+      continue;
+    }
+    let cursor = sshStart + "ssh".length;
+    for (;;) {
+      const wordStart = skipWhitespace(input, cursor);
+      if (wordStart >= input.length || isShellCommandBoundary(input[wordStart])) {
+        break;
+      }
+      const wordEnd = findShellWordEnd(input, wordStart);
+      const word = input.slice(wordStart, wordEnd);
+      if (word === "--") {
+        break;
+      }
+      if (word === "-i") {
+        const valueStart = skipWhitespace(input, wordEnd);
+        if (valueStart >= input.length) {
+          break;
+        }
+        const valueEnd = findShellWordEnd(input, valueStart);
+        output += input.slice(lastIndex, valueStart);
+        output += "<redacted>";
+        lastIndex = valueEnd;
+        cursor = valueEnd;
+        continue;
+      }
+      if (!word.startsWith("-") || word === "-") {
+        break;
+      }
+      cursor = SSH_OPTIONS_WITH_VALUE.has(word) ? findShellWordEnd(input, skipWhitespace(input, wordEnd)) : wordEnd;
+    }
+  }
+
+  return output + input.slice(lastIndex);
+}
+
+function skipWhitespace(input: string, start: number): number {
+  let index = start;
+  while (index < input.length && /\s/.test(input[index])) {
+    index += 1;
+  }
+  return index;
+}
+
+function isShellCommandBoundary(char: string): boolean {
+  return char === ";" || char === "&" || char === "|" || char === ")";
 }
 
 function findShellWordEnd(input: string, start: number): number {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -43,6 +43,7 @@ type OpenSshOptionAction =
   | { kind: "identity-attached"; valueStart: number }
   | { kind: "value-next" }
   | { kind: "value-attached"; valueStart: number };
+type ShellRedirectionAction = { kind: "attached-target" } | { kind: "next-target" };
 
 export function redactText(input: string, extraRedactions: string[] = []): string {
   let output = input;
@@ -133,7 +134,7 @@ function collectSshIdentityRanges(input: string, start: number, end: number, ran
       continue;
     }
     const optionsWithValue = OPENSSH_COMMAND_OPTIONS_WITH_VALUE[commandName];
-    cursor = sshEnd;
+    cursor = findOpenSshCommandWordEnd(input, sshStart, sshEnd);
     for (;;) {
       const wordStart = skipShellWhitespace(input, cursor);
       if (wordStart >= end || isShellCommandBoundary(input[wordStart])) {
@@ -143,6 +144,18 @@ function collectSshIdentityRanges(input: string, start: number, end: number, ran
       const word = input.slice(wordStart, wordEnd);
       if (word === "--") {
         break;
+      }
+      const redirectionAction = classifyShellRedirectionWord(word);
+      if (redirectionAction) {
+        cursor = wordEnd;
+        if (redirectionAction.kind === "next-target") {
+          const targetStart = skipShellWhitespace(input, cursor);
+          if (targetStart >= end) {
+            break;
+          }
+          cursor = Math.min(findShellWordEnd(input, targetStart), end);
+        }
+        continue;
       }
       if (!word.startsWith("-") || word === "-") {
         break;
@@ -209,6 +222,31 @@ function classifyOpenSshOptionWord(word: string, optionsWithValue: Set<string>):
     }
   }
   return { kind: "flag" };
+}
+
+function classifyShellRedirectionWord(word: string): ShellRedirectionAction | undefined {
+  let index = 0;
+  while (index < word.length && /\d/.test(word[index])) {
+    index += 1;
+  }
+  const rest = word.slice(index);
+  if (rest.startsWith("<(") || rest.startsWith(">(")) {
+    return undefined;
+  }
+  for (const operator of ["<<<", ">>", "<<", "<>", ">&", "<&", ">|", ">", "<"]) {
+    if (rest.startsWith(operator)) {
+      return rest.length === operator.length ? { kind: "next-target" } : { kind: "attached-target" };
+    }
+  }
+  return undefined;
+}
+
+function findOpenSshCommandWordEnd(input: string, commandStart: number, commandEnd: number): number {
+  const quote = input[commandStart - 1];
+  if ((quote === "'" || quote === "\"") && input[commandEnd] === quote) {
+    return commandEnd + 1;
+  }
+  return commandEnd;
 }
 
 function getOpenSshCommandName(commandName: string | undefined): OpenSshCommand | undefined {
@@ -285,6 +323,11 @@ function findCommandValueEnd(input: string, start: number): number {
       escaped = true;
       continue;
     }
+    const substitutionEnd = findShellSubstitutionEnd(input, index);
+    if (substitutionEnd !== undefined) {
+      index = substitutionEnd - 1;
+      continue;
+    }
     if (/\s/.test(char) || char === "'" || char === "\"" || char === "`" || isShellCommandBoundary(char)) {
       return index;
     }
@@ -310,7 +353,7 @@ function findShellWordEnd(input: string, start: number): number {
     if (!quote && substitutionDepth === 0 && /\s/.test(char)) {
       return index;
     }
-    if (!quote && isShellSubstitutionStart(input, index)) {
+    if (!quote && findShellSubstitutionEnd(input, index) !== undefined) {
       substitutionDepth += 1;
       index += 1;
       continue;
@@ -337,6 +380,46 @@ function isShellSubstitutionStart(input: string, index: number): boolean {
     return false;
   }
   return input[index] === "<" || input[index] === ">" || input[index] === "$";
+}
+
+function findShellSubstitutionEnd(input: string, start: number): number | undefined {
+  if (!isShellSubstitutionStart(input, start)) {
+    return undefined;
+  }
+  let depth = 1;
+  let quote: "'" | "\"" | undefined;
+  let escaped = false;
+  for (let index = start + 2; index < input.length; index += 1) {
+    const char = input[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (!quote && isShellSubstitutionStart(input, index)) {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (!quote && char === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index + 1;
+      }
+      continue;
+    }
+    if (!quote && (char === "'" || char === "\"")) {
+      quote = char;
+      continue;
+    }
+    if (quote && char === quote) {
+      quote = undefined;
+    }
+  }
+  return input.length;
 }
 
 function splitTopLevelShellParts(input: string): Array<{ text: string; isWord: boolean }> {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -76,7 +76,7 @@ function redactSensitiveFlagValues(input: string): string {
 
   SENSITIVE_FLAG_PATTERN.lastIndex = 0;
   while ((match = SENSITIVE_FLAG_PATTERN.exec(input)) !== null) {
-    const valueStart = match.index + match[0].length;
+    const valueStart = skipShellWhitespace(input, match.index + match[0].length);
     if (valueStart >= input.length) {
       continue;
     }
@@ -119,7 +119,7 @@ function redactSshIdentityValues(input: string): string {
     }
     cursor = sshEnd;
     for (;;) {
-      const wordStart = skipWhitespace(input, cursor);
+      const wordStart = skipShellWhitespace(input, cursor);
       if (wordStart >= input.length || isShellCommandBoundary(input[wordStart])) {
         break;
       }
@@ -129,7 +129,7 @@ function redactSshIdentityValues(input: string): string {
         break;
       }
       if (word === "-i") {
-        const valueStart = skipWhitespace(input, wordEnd);
+        const valueStart = skipShellWhitespace(input, wordEnd);
         if (valueStart >= input.length) {
           break;
         }
@@ -143,7 +143,7 @@ function redactSshIdentityValues(input: string): string {
       if (!word.startsWith("-") || word === "-") {
         break;
       }
-      cursor = SSH_OPTIONS_WITH_VALUE.has(word) ? findShellWordEnd(input, skipWhitespace(input, wordEnd)) : wordEnd;
+      cursor = SSH_OPTIONS_WITH_VALUE.has(word) ? findShellWordEnd(input, skipShellWhitespace(input, wordEnd)) : wordEnd;
     }
   }
 
@@ -174,16 +174,35 @@ function isSshScanBoundary(char: string): boolean {
   return /\s/.test(char) || char === "'" || char === "\"" || char === "`" || isShellCommandBoundary(char);
 }
 
-function skipWhitespace(input: string, start: number): number {
+function skipShellWhitespace(input: string, start: number): number {
   let index = start;
-  while (index < input.length && /\s/.test(input[index])) {
-    index += 1;
+  for (;;) {
+    while (index < input.length && /\s/.test(input[index])) {
+      index += 1;
+    }
+    const continuationLength = shellLineContinuationLength(input, index);
+    if (continuationLength === 0) {
+      return index;
+    }
+    index += continuationLength;
   }
-  return index;
+}
+
+function shellLineContinuationLength(input: string, index: number): number {
+  if (input[index] !== "\\") {
+    return 0;
+  }
+  if (input[index + 1] === "\n") {
+    return 2;
+  }
+  if (input[index + 1] === "\r") {
+    return input[index + 2] === "\n" ? 3 : 2;
+  }
+  return 0;
 }
 
 function isShellCommandBoundary(char: string): boolean {
-  return char === ";" || char === "&" || char === "|" || char === ")";
+  return char === ";" || char === "&" || char === "|" || char === "(" || char === ")";
 }
 
 function findShellWordEnd(input: string, start: number): number {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -9,8 +9,8 @@ const SENSITIVE_FLAGS = [
 ] as const;
 const SENSITIVE_FLAG_SET = new Set<string>(SENSITIVE_FLAGS);
 const SENSITIVE_FLAG_PATTERN = buildSensitiveFlagPattern(SENSITIVE_FLAGS);
-const SSH_COMMAND_PATTERN = /(^|[\s'"`;&|()])ssh(?=$|[\s'"`;&|()])/g;
 const SSH_OPTIONS_WITH_VALUE = new Set([
+  "-B",
   "-b",
   "-c",
   "-D",
@@ -24,6 +24,7 @@ const SSH_OPTIONS_WITH_VALUE = new Set([
   "-m",
   "-O",
   "-o",
+  "-P",
   "-p",
   "-Q",
   "-R",
@@ -56,7 +57,7 @@ export function redactCommand(command: string, extraRedactions: string[] = []): 
       return "<redacted>";
     }
     const flag = part.text.includes("=") ? part.text.slice(0, part.text.indexOf("=")) : part.text;
-    const isSensitiveFlag = SENSITIVE_FLAG_SET.has(flag) || (commandName === "ssh" && flag === "-i");
+    const isSensitiveFlag = SENSITIVE_FLAG_SET.has(flag) || (isSshCommandName(commandName) && flag === "-i");
     if (isSensitiveFlag) {
       if (part.text.includes("=")) {
         return `${flag}=<redacted>`;
@@ -104,15 +105,19 @@ function escapeRegExp(value: string): string {
 function redactSshIdentityValues(input: string): string {
   let output = "";
   let lastIndex = 0;
-  let match: RegExpExecArray | null;
+  let cursor = 0;
 
-  SSH_COMMAND_PATTERN.lastIndex = 0;
-  while ((match = SSH_COMMAND_PATTERN.exec(input)) !== null) {
-    const sshStart = match.index + match[1].length;
-    if (sshStart < lastIndex) {
+  while (cursor < input.length) {
+    const sshStart = findNextSshWordStart(input, cursor);
+    if (sshStart >= input.length) {
+      break;
+    }
+    const sshEnd = findSshWordEnd(input, sshStart);
+    if (!isSshCommandName(input.slice(sshStart, sshEnd))) {
+      cursor = sshEnd;
       continue;
     }
-    let cursor = sshStart + "ssh".length;
+    cursor = sshEnd;
     for (;;) {
       const wordStart = skipWhitespace(input, cursor);
       if (wordStart >= input.length || isShellCommandBoundary(input[wordStart])) {
@@ -143,6 +148,30 @@ function redactSshIdentityValues(input: string): string {
   }
 
   return output + input.slice(lastIndex);
+}
+
+function isSshCommandName(commandName: string | undefined): boolean {
+  return commandName === "ssh" || commandName?.endsWith("/ssh") === true;
+}
+
+function findNextSshWordStart(input: string, start: number): number {
+  let index = start;
+  while (index < input.length && isSshScanBoundary(input[index])) {
+    index += 1;
+  }
+  return index;
+}
+
+function findSshWordEnd(input: string, start: number): number {
+  let index = start;
+  while (index < input.length && !isSshScanBoundary(input[index])) {
+    index += 1;
+  }
+  return index;
+}
+
+function isSshScanBoundary(char: string): boolean {
+  return /\s/.test(char) || char === "'" || char === "\"" || char === "`" || isShellCommandBoundary(char);
 }
 
 function skipWhitespace(input: string, start: number): number {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,4 +1,4 @@
-const SENSITIVE_FLAGS = new Set([
+const SENSITIVE_FLAGS = [
   "--password",
   "--password-file",
   "--token-file",
@@ -6,7 +6,9 @@ const SENSITIVE_FLAGS = new Set([
   "--access-token",
   "--private-key",
   "--sa-key-file"
-]);
+] as const;
+const SENSITIVE_FLAG_SET = new Set<string>(SENSITIVE_FLAGS);
+const SENSITIVE_FLAG_PATTERN = buildSensitiveFlagPattern(SENSITIVE_FLAGS);
 
 export function redactText(input: string, extraRedactions: string[] = []): string {
   let output = input;
@@ -32,7 +34,7 @@ export function redactCommand(command: string, extraRedactions: string[] = []): 
       return "<redacted>";
     }
     const flag = part.text.includes("=") ? part.text.slice(0, part.text.indexOf("=")) : part.text;
-    const isSensitiveFlag = SENSITIVE_FLAGS.has(flag) || (commandName === "ssh" && flag === "-i");
+    const isSensitiveFlag = SENSITIVE_FLAG_SET.has(flag) || (commandName === "ssh" && flag === "-i");
     if (isSensitiveFlag) {
       if (part.text.includes("=")) {
         return `${flag}=<redacted>`;
@@ -45,12 +47,12 @@ export function redactCommand(command: string, extraRedactions: string[] = []): 
 }
 
 function redactSensitiveFlagValues(input: string): string {
-  const flagPattern = /--(?:password-file|auth-token-file|token-file|access-token|private-key|sa-key-file|password)(?:=|\s+)/g;
   let output = "";
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
-  while ((match = flagPattern.exec(input)) !== null) {
+  SENSITIVE_FLAG_PATTERN.lastIndex = 0;
+  while ((match = SENSITIVE_FLAG_PATTERN.exec(input)) !== null) {
     const valueStart = match.index + match[0].length;
     if (valueStart >= input.length) {
       continue;
@@ -59,10 +61,22 @@ function redactSensitiveFlagValues(input: string): string {
     output += input.slice(lastIndex, valueStart);
     output += "<redacted>";
     lastIndex = valueEnd;
-    flagPattern.lastIndex = valueEnd;
+    SENSITIVE_FLAG_PATTERN.lastIndex = valueEnd;
   }
 
   return output + input.slice(lastIndex);
+}
+
+function buildSensitiveFlagPattern(flags: readonly string[]): RegExp {
+  const pattern = [...flags]
+    .sort((left, right) => right.length - left.length)
+    .map(escapeRegExp)
+    .join("|");
+  return new RegExp(`(?:${pattern})(?:=|\\s+)`, "g");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
 }
 
 function findShellWordEnd(input: string, start: number): number {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -80,7 +80,7 @@ function redactSensitiveFlagValues(input: string): string {
     if (valueStart >= input.length) {
       continue;
     }
-    const valueEnd = findShellWordEnd(input, valueStart);
+    const valueEnd = findCommandValueEnd(input, valueStart);
     output += input.slice(lastIndex, valueStart);
     output += "<redacted>";
     lastIndex = valueEnd;
@@ -103,13 +103,16 @@ function escapeRegExp(value: string): string {
 }
 
 function redactSshIdentityValues(input: string): string {
-  let output = "";
-  let lastIndex = 0;
-  let cursor = 0;
+  const ranges: Array<{ start: number; end: number }> = [];
+  collectSshIdentityRanges(input, 0, input.length, ranges);
+  return redactRanges(input, ranges);
+}
 
+function collectSshIdentityRanges(input: string, start: number, end: number, ranges: Array<{ start: number; end: number }>): void {
+  let cursor = start;
   while (cursor < input.length) {
     const sshStart = findNextSshWordStart(input, cursor);
-    if (sshStart >= input.length) {
+    if (sshStart >= end) {
       break;
     }
     const sshEnd = findSshWordEnd(input, sshStart);
@@ -130,24 +133,49 @@ function redactSshIdentityValues(input: string): string {
       }
       if (word === "-i") {
         const valueStart = skipShellWhitespace(input, wordEnd);
-        if (valueStart >= input.length) {
+        if (valueStart >= end) {
           break;
         }
-        const valueEnd = findShellWordEnd(input, valueStart);
-        output += input.slice(lastIndex, valueStart);
-        output += "<redacted>";
-        lastIndex = valueEnd;
+        const valueEnd = Math.min(findCommandValueEnd(input, valueStart), end);
+        ranges.push({ start: valueStart, end: valueEnd });
         cursor = valueEnd;
+        continue;
+      }
+      if (word.startsWith("-i") && word.length > 2) {
+        ranges.push({ start: wordStart + 2, end: wordEnd });
+        cursor = wordEnd;
         continue;
       }
       if (!word.startsWith("-") || word === "-") {
         break;
       }
-      cursor = SSH_OPTIONS_WITH_VALUE.has(word) ? findShellWordEnd(input, skipShellWhitespace(input, wordEnd)) : wordEnd;
+      if (SSH_OPTIONS_WITH_VALUE.has(word)) {
+        const valueStart = skipShellWhitespace(input, wordEnd);
+        const valueEnd = Math.min(findShellWordEnd(input, valueStart), end);
+        collectSshIdentityRanges(input, valueStart, valueEnd, ranges);
+        cursor = valueEnd;
+      } else {
+        cursor = wordEnd;
+      }
     }
   }
+}
 
-  return output + input.slice(lastIndex);
+function redactRanges(input: string, ranges: Array<{ start: number; end: number }>): string {
+  const sorted = ranges
+    .filter((range) => range.start < range.end)
+    .sort((left, right) => left.start - right.start || right.end - left.end);
+  let output = "";
+  let cursor = 0;
+  for (const range of sorted) {
+    if (range.end <= cursor) {
+      continue;
+    }
+    output += input.slice(cursor, Math.max(range.start, cursor));
+    output += "<redacted>";
+    cursor = range.end;
+  }
+  return output + input.slice(cursor);
 }
 
 function isSshCommandName(commandName: string | undefined): boolean {
@@ -203,6 +231,28 @@ function shellLineContinuationLength(input: string, index: number): number {
 
 function isShellCommandBoundary(char: string): boolean {
   return char === ";" || char === "&" || char === "|" || char === "(" || char === ")";
+}
+
+function findCommandValueEnd(input: string, start: number): number {
+  if (input[start] === "'" || input[start] === "\"") {
+    return findShellWordEnd(input, start);
+  }
+  let escaped = false;
+  for (let index = start; index < input.length; index += 1) {
+    const char = input[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (/\s/.test(char) || char === "'" || char === "\"" || char === "`" || isShellCommandBoundary(char)) {
+      return index;
+    }
+  }
+  return input.length;
 }
 
 function findShellWordEnd(input: string, start: number): number {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -22,7 +22,7 @@ export function redactCommand(command: string, extraRedactions: string[] = []): 
   const parts = splitTopLevelShellParts(command);
   let redactNext = false;
   let commandName: string | undefined;
-  return redactText(parts.map((part) => {
+  const topLevelRedacted = parts.map((part) => {
     if (!part.isWord) {
       return part.text;
     }
@@ -40,7 +40,66 @@ export function redactCommand(command: string, extraRedactions: string[] = []): 
       redactNext = true;
     }
     return part.text;
-  }).join(""), extraRedactions);
+  }).join("");
+  return redactText(redactSensitiveFlagValues(topLevelRedacted), extraRedactions);
+}
+
+function redactSensitiveFlagValues(input: string): string {
+  const flagPattern = /--(?:password-file|auth-token-file|token-file|access-token|private-key|sa-key-file|password)(?:=|\s+)/g;
+  let output = "";
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = flagPattern.exec(input)) !== null) {
+    const valueStart = match.index + match[0].length;
+    if (valueStart >= input.length) {
+      continue;
+    }
+    const valueEnd = findShellWordEnd(input, valueStart);
+    output += input.slice(lastIndex, valueStart);
+    output += "<redacted>";
+    lastIndex = valueEnd;
+    flagPattern.lastIndex = valueEnd;
+  }
+
+  return output + input.slice(lastIndex);
+}
+
+function findShellWordEnd(input: string, start: number): number {
+  let quote: "'" | "\"" | undefined;
+  let escaped = false;
+  let sawUnquoted = false;
+
+  for (let index = start; index < input.length; index += 1) {
+    const char = input[index];
+    if (escaped) {
+      escaped = false;
+      sawUnquoted = true;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      sawUnquoted = true;
+      continue;
+    }
+    if (!quote && /\s/.test(char)) {
+      return index;
+    }
+    if (!quote && (char === "'" || char === "\"")) {
+      if (sawUnquoted) {
+        return index;
+      }
+      quote = char;
+      continue;
+    }
+    if (quote && char === quote) {
+      quote = undefined;
+      continue;
+    }
+    sawUnquoted = true;
+  }
+
+  return input.length;
 }
 
 function splitTopLevelShellParts(input: string): Array<{ text: string; isWord: boolean }> {
@@ -66,6 +125,13 @@ function splitTopLevelShellParts(input: string): Array<{ text: string; isWord: b
   }
 
   for (const char of input) {
+    if (escaped) {
+      pushWhitespace();
+      current += char;
+      escaped = false;
+      continue;
+    }
+
     if (!inSingleQuote && !inDoubleQuote && /\s/.test(char)) {
       pushWord();
       whitespace += char;
@@ -74,11 +140,6 @@ function splitTopLevelShellParts(input: string): Array<{ text: string; isWord: b
 
     pushWhitespace();
     current += char;
-
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
 
     if (char === "\\" && !inSingleQuote) {
       escaped = true;

--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -1,5 +1,6 @@
 import { dirname } from "node:path";
 import { bash, shellQuote } from "../api-client.js";
+import { pathRedactions } from "../redactions.js";
 import { commandForDynamicRun, createTenantSpec, waitForYdbCli } from "./commands.js";
 import { planOnly, runMutating } from "./execution.js";
 import { commandForStaticGeneratedConfigPath } from "./generated-config.js";
@@ -448,14 +449,4 @@ export async function setRootPassword(
     verification,
     results
   };
-}
-
-function pathRedactions(...paths: Array<string | undefined>): string[] {
-  return paths.flatMap((path) => {
-    if (!path) {
-      return [];
-    }
-    const parent = dirname(path);
-    return parent === "." || parent === "/" || parent === path ? [path] : [path, parent];
-  });
 }

--- a/packages/core/src/operations/auth-operations.ts
+++ b/packages/core/src/operations/auth-operations.ts
@@ -24,7 +24,9 @@ export async function applyAuthHardening(ctx: ToolkitContext, options: MutatingO
     summary: `Apply reviewed YDB auth config from ${configHostPath}.`,
     risk: "high",
     specs: [
-      bash(`docker cp ${shellQuote(configHostPath)} ${shellQuote(`${ctx.profile.staticContainer}:/tmp/local-ydb-toolkit-config.yaml`)}`),
+      bash(`docker cp ${shellQuote(configHostPath)} ${shellQuote(`${ctx.profile.staticContainer}:/tmp/local-ydb-toolkit-config.yaml`)}`, {
+        redactions: pathRedactions(configHostPath)
+      }),
       bash([
         "set -euo pipefail",
         `target=$(${targetCommand})`,
@@ -171,7 +173,9 @@ export async function prepareAuthConfig(
   return runMutating(ctx, {
     summary: `Prepare hardened auth config at ${configHostPath}.`,
     risk: "medium",
-    specs: [bash(script)],
+    specs: [bash(script, {
+      redactions: pathRedactions(configHostPath, rootPasswordFile)
+    })],
     rollback: [
       `rm -f ${configHostPath}`,
       ...(rootPasswordFile ? [`rm -f ${rootPasswordFile}`] : [])
@@ -207,7 +211,8 @@ export async function writeDynamicNodeAuthConfig(
     risk: "medium",
     specs: [
       bash(
-        `install -d -m 0700 ${shellQuote(dirname(tokenHostPath))} && printf '%s\n' ${shellQuote(staffToken)} ${shellQuote(registrationToken)} > ${shellQuote(tokenHostPath)} && chmod 600 ${shellQuote(tokenHostPath)}`
+        `install -d -m 0700 ${shellQuote(dirname(tokenHostPath))} && printf '%s\n' ${shellQuote(staffToken)} ${shellQuote(registrationToken)} > ${shellQuote(tokenHostPath)} && chmod 600 ${shellQuote(tokenHostPath)}`,
+        { redactions: pathRedactions(tokenHostPath) }
       )
     ],
     rollback: [`rm -f ${tokenHostPath}`],
@@ -443,4 +448,14 @@ export async function setRootPassword(
     verification,
     results
   };
+}
+
+function pathRedactions(...paths: Array<string | undefined>): string[] {
+  return paths.flatMap((path) => {
+    if (!path) {
+      return [];
+    }
+    const parent = dirname(path);
+    return parent === "." || parent === "/" || parent === path ? [path] : [path, parent];
+  });
 }

--- a/packages/core/src/operations/scheme.ts
+++ b/packages/core/src/operations/scheme.ts
@@ -53,6 +53,7 @@ function schemeArgs(action: SchemeAction, path: string, options: SchemeOptions):
     if (options.stats) {
       throw new Error("stats is only supported when action is describe");
     }
+    // local-ydb 26.1.1.6 rejects this documented-looking pair with "Options -1 and -l are incompatible".
     if (options.long && options.onePerLine) {
       throw new Error("long and onePerLine cannot be used together because YDB CLI flags -l and -1 are incompatible");
     }

--- a/packages/core/src/operations/scheme.ts
+++ b/packages/core/src/operations/scheme.ts
@@ -53,6 +53,9 @@ function schemeArgs(action: SchemeAction, path: string, options: SchemeOptions):
     if (options.stats) {
       throw new Error("stats is only supported when action is describe");
     }
+    if (options.long && options.onePerLine) {
+      throw new Error("long and onePerLine cannot be used together because YDB CLI flags -l and -1 are incompatible");
+    }
     return [
       "scheme",
       "ls",

--- a/packages/core/src/redactions.ts
+++ b/packages/core/src/redactions.ts
@@ -4,6 +4,15 @@ export function pathRedactions(...paths: Array<string | undefined>): string[] {
   const exactPaths = paths.filter((path): path is string => Boolean(path));
   const parentPaths = exactPaths
     .map((path) => dirname(path))
-    .filter((parent, index) => parent !== "." && parent !== "/" && parent !== exactPaths[index]);
+    .filter((parent, index) => parent !== exactPaths[index] && isSpecificParentDirectory(parent));
   return [...exactPaths, ...parentPaths];
+}
+
+function isSpecificParentDirectory(parent: string): boolean {
+  const normalized = parent.replace(/\/+$/, "") || "/";
+  if ([".", "/", "/tmp", "/var/tmp", "/home", "/Users"].includes(normalized)) {
+    return false;
+  }
+  const parts = normalized.split("/").filter(Boolean);
+  return !((parts[0] === "home" || parts[0] === "Users") && parts.length <= 2);
 }

--- a/packages/core/src/redactions.ts
+++ b/packages/core/src/redactions.ts
@@ -9,10 +9,18 @@ export function pathRedactions(...paths: Array<string | undefined>): string[] {
 }
 
 function isSpecificParentDirectory(parent: string): boolean {
-  const normalized = parent.replace(/\/+$/, "") || "/";
+  const normalized = stripTrailingSlashes(parent);
   if ([".", "/", "/tmp", "/var/tmp", "/home", "/Users"].includes(normalized)) {
     return false;
   }
   const parts = normalized.split("/").filter(Boolean);
   return !((parts[0] === "home" || parts[0] === "Users") && parts.length <= 2);
+}
+
+function stripTrailingSlashes(path: string): string {
+  let end = path.length;
+  while (end > 0 && path.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return end === 0 ? "/" : path.slice(0, end);
 }

--- a/packages/core/src/redactions.ts
+++ b/packages/core/src/redactions.ts
@@ -1,0 +1,9 @@
+import { dirname } from "node:path";
+
+export function pathRedactions(...paths: Array<string | undefined>): string[] {
+  const exactPaths = paths.filter((path): path is string => Boolean(path));
+  const parentPaths = exactPaths
+    .map((path) => dirname(path))
+    .filter((parent, index) => parent !== "." && parent !== "/" && parent !== exactPaths[index]);
+  return [...exactPaths, ...parentPaths];
+}

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -51,6 +51,10 @@ Status {
 
   it("redacts sensitive command flags and profile values", () => {
     expect(redactCommand("ydb --password-file /secret/root.password --token-file abc")).toContain("--password-file <redacted>");
+    expect(redactCommand("docker rm -f ydb-local")).toBe("docker rm -f ydb-local");
+    expect(redactCommand("docker exec -i ydb-local true")).toBe("docker exec -i ydb-local true");
+    expect(redactCommand("ssh -i /secret/key host true")).toBe("ssh -i <redacted> host true");
+    expect(redactCommand("bash -lc 'rm -f /tmp/secret'", ["/tmp/secret"])).toBe("bash -lc 'rm -f <redacted>'");
   });
 
   it("formats ssh commands with safe defaults", () => {

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -6,6 +6,7 @@ import {
   parseReadStoragePools,
   redactCommand,
   ShellCommandExecutor,
+  shellQuote,
   type CommandExecutor,
   type CommandResult,
   type CommandSpec
@@ -55,6 +56,29 @@ Status {
     expect(redactCommand("docker exec -i ydb-local true")).toBe("docker exec -i ydb-local true");
     expect(redactCommand("ssh -i /secret/key host true")).toBe("ssh -i <redacted> host true");
     expect(redactCommand("bash -lc 'rm -f /tmp/secret'", ["/tmp/secret"])).toBe("bash -lc 'rm -f <redacted>'");
+    expect(redactCommand("bash -lc 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");
+    expect(redactCommand("bash -lc\\ 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc\\ 'ydb --token-file <redacted> scheme ls'");
+    expect(redactCommand("bash -lc\\ 'rm -f /tmp/secret path'", ["/tmp/secret path"])).toBe("bash -lc\\ 'rm -f <redacted>'");
+  });
+
+  it("redacts shell-quoted profile paths before rendering display commands", () => {
+    const authConfigPath = "/tmp/local-ydb-auth/quote'd/config.auth.yaml";
+    const profile = resolveProfile(ConfigSchema.parse({
+      profiles: {
+        default: {
+          authConfigPath
+        }
+      }
+    }));
+
+    const command = new ShellCommandExecutor().display(profile, {
+      command: "bash",
+      args: ["-lc", `rm -f ${shellQuote(authConfigPath)}`]
+    });
+
+    expect(command).toBe("bash -lc 'rm -f <redacted>'");
+    expect(command).not.toContain("/tmp/local-ydb-auth");
+    expect(command).not.toContain("quote");
   });
 
   it("formats ssh commands with safe defaults", () => {

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -60,10 +60,14 @@ Status {
     expect(redactCommand("ssh -i /secret/key host true")).toBe("ssh -i <redacted> host true");
     expect(redactCommand("ssh -i/secret/key host true")).toBe("ssh -i<redacted> host true");
     expect(redactCommand("/usr/bin/ssh -i /secret/key host true")).toBe("/usr/bin/ssh -i <redacted> host true");
+    expect(redactCommand("'/usr/bin/ssh' -i /secret/key host true")).toBe("'/usr/bin/ssh' -i <redacted> host true");
     expect(redactCommand("scp -i /secret/key file host:/tmp")).toBe("scp -i <redacted> file host:/tmp");
     expect(redactCommand("sftp -i /secret/key host")).toBe("sftp -i <redacted> host");
     expect(redactCommand("bash -lc 'ssh -i /secret/key host true'")).toBe("bash -lc 'ssh -i <redacted> host true'");
+    expect(redactCommand("bash -lc '\"/usr/bin/ssh\" -i /secret/key host true'")).toBe("bash -lc '\"/usr/bin/ssh\" -i <redacted> host true'");
     expect(redactCommand("bash -lc 'ssh -vi /secret/key host true'")).toBe("bash -lc 'ssh -vi <redacted> host true'");
+    expect(redactCommand("bash -lc 'ssh </dev/null -i /secret/key host true'")).toBe("bash -lc 'ssh </dev/null -i <redacted> host true'");
+    expect(redactCommand("bash -lc 'ssh 2>/tmp/err -i /secret/key host true'")).toBe("bash -lc 'ssh 2>/tmp/err -i <redacted> host true'");
     expect(redactCommand("bash -lc '/usr/bin/ssh -B eth0 -P tag -i /secret/key host true'")).toBe("bash -lc '/usr/bin/ssh -B eth0 -P tag -i <redacted> host true'");
     expect(redactCommand("bash -lc 'ssh -o ProxyCommand=\"ssh -i /secret/key jump\" host true'")).toBe("bash -lc 'ssh -o ProxyCommand=\"ssh -i <redacted> jump\" host true'");
     expect(redactCommand("bash -lc 'ssh -oProxyCommand=\"ssh -i /secret/key jump\" host true'")).toBe("bash -lc 'ssh -oProxyCommand=\"ssh -i <redacted> jump\" host true'");
@@ -77,6 +81,8 @@ Status {
     expect(redactCommand(`bash -lc 'ssh ${lineContinuation} -i /secret/key host true'`)).toBe(`bash -lc 'ssh ${lineContinuation} -i <redacted> host true'`);
     expect(redactCommand("bash -lc 'rm -f /tmp/secret'", ["/tmp/secret"])).toBe("bash -lc 'rm -f <redacted>'");
     expect(redactCommand("bash -lc 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");
+    expect(redactCommand("bash -lc 'ydb --token-file $(cat /secret/token-path) scheme ls'")).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");
+    expect(redactCommand("bash -lc 'ssh -i $(cat /secret/key-path) host true'")).toBe("bash -lc 'ssh -i <redacted> host true'");
     expect(redactCommand("bash -lc 'cmd=\"ydb --token-file /secret/token\"; echo ok'")).toBe("bash -lc 'cmd=\"ydb --token-file <redacted>\"; echo ok'");
     expect(redactCommand(`bash -lc 'ydb --token-file ${lineContinuation} /secret/token scheme ls'`)).toBe(`bash -lc 'ydb --token-file ${lineContinuation} <redacted> scheme ls'`);
     expect(redactCommand("bash -lc\\ 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc\\ 'ydb --token-file <redacted> scheme ls'");

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -63,10 +63,15 @@ Status {
     expect(redactCommand("scp -i /secret/key file host:/tmp")).toBe("scp -i <redacted> file host:/tmp");
     expect(redactCommand("sftp -i /secret/key host")).toBe("sftp -i <redacted> host");
     expect(redactCommand("bash -lc 'ssh -i /secret/key host true'")).toBe("bash -lc 'ssh -i <redacted> host true'");
+    expect(redactCommand("bash -lc 'ssh -vi /secret/key host true'")).toBe("bash -lc 'ssh -vi <redacted> host true'");
     expect(redactCommand("bash -lc '/usr/bin/ssh -B eth0 -P tag -i /secret/key host true'")).toBe("bash -lc '/usr/bin/ssh -B eth0 -P tag -i <redacted> host true'");
     expect(redactCommand("bash -lc 'ssh -o ProxyCommand=\"ssh -i /secret/key jump\" host true'")).toBe("bash -lc 'ssh -o ProxyCommand=\"ssh -i <redacted> jump\" host true'");
     expect(redactCommand("bash -lc 'ssh -oProxyCommand=\"ssh -i /secret/key jump\" host true'")).toBe("bash -lc 'ssh -oProxyCommand=\"ssh -i <redacted> jump\" host true'");
     expect(redactCommand("bash -lc 'ssh -F <(printf x) -i /secret/key host'")).toBe("bash -lc 'ssh -F <(printf x) -i <redacted> host'");
+    expect(redactCommand("bash -lc 'scp -X nrequests=64 -i /secret/key file host:/tmp'")).toBe("bash -lc 'scp -X nrequests=64 -i <redacted> file host:/tmp'");
+    expect(redactCommand("bash -lc 'sftp -s subsystem -i /secret/key host'")).toBe("bash -lc 'sftp -s subsystem -i <redacted> host'");
+    expect(redactCommand("bash -lc 'scp -p -i /secret/key file host:/tmp'")).toBe("bash -lc 'scp -p -i <redacted> file host:/tmp'");
+    expect(redactCommand("bash -lc 'sftp -p -i /secret/key host'")).toBe("bash -lc 'sftp -p -i <redacted> host'");
     expect(redactCommand("env ssh -i /secret/key host true")).toBe("env ssh -i <redacted> host true");
     expect(redactCommand("bash -lc 'out=$(ssh -i /secret/key host true)'")).toBe("bash -lc 'out=$(ssh -i <redacted> host true)'");
     expect(redactCommand(`bash -lc 'ssh ${lineContinuation} -i /secret/key host true'`)).toBe(`bash -lc 'ssh ${lineContinuation} -i <redacted> host true'`);

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -52,6 +52,8 @@ Status {
   });
 
   it("redacts sensitive command flags and profile values", () => {
+    const lineContinuation = "\\\n";
+
     expect(redactCommand("ydb --password-file /secret/root.password --token-file abc")).toContain("--password-file <redacted>");
     expect(redactCommand("docker rm -f ydb-local")).toBe("docker rm -f ydb-local");
     expect(redactCommand("docker exec -i ydb-local true")).toBe("docker exec -i ydb-local true");
@@ -60,8 +62,11 @@ Status {
     expect(redactCommand("bash -lc 'ssh -i /secret/key host true'")).toBe("bash -lc 'ssh -i <redacted> host true'");
     expect(redactCommand("bash -lc '/usr/bin/ssh -B eth0 -P tag -i /secret/key host true'")).toBe("bash -lc '/usr/bin/ssh -B eth0 -P tag -i <redacted> host true'");
     expect(redactCommand("env ssh -i /secret/key host true")).toBe("env ssh -i <redacted> host true");
+    expect(redactCommand("bash -lc 'out=$(ssh -i /secret/key host true)'")).toBe("bash -lc 'out=$(ssh -i <redacted> host true)'");
+    expect(redactCommand(`bash -lc 'ssh ${lineContinuation} -i /secret/key host true'`)).toBe(`bash -lc 'ssh ${lineContinuation} -i <redacted> host true'`);
     expect(redactCommand("bash -lc 'rm -f /tmp/secret'", ["/tmp/secret"])).toBe("bash -lc 'rm -f <redacted>'");
     expect(redactCommand("bash -lc 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");
+    expect(redactCommand(`bash -lc 'ydb --token-file ${lineContinuation} /secret/token scheme ls'`)).toBe(`bash -lc 'ydb --token-file ${lineContinuation} <redacted> scheme ls'`);
     expect(redactCommand("bash -lc\\ 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc\\ 'ydb --token-file <redacted> scheme ls'");
     expect(redactCommand("bash -lc\\ 'rm -f /tmp/secret path'", ["/tmp/secret path"])).toBe("bash -lc\\ 'rm -f <redacted>'");
     expect(redactCommand(`bash -lc 'ydb --token-file ${shellQuote("/tmp/quote'd/token file")} scheme ls'`)).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -59,6 +59,7 @@ Status {
     expect(redactCommand("bash -lc 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");
     expect(redactCommand("bash -lc\\ 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc\\ 'ydb --token-file <redacted> scheme ls'");
     expect(redactCommand("bash -lc\\ 'rm -f /tmp/secret path'", ["/tmp/secret path"])).toBe("bash -lc\\ 'rm -f <redacted>'");
+    expect(redactCommand(`bash -lc 'ydb --token-file ${shellQuote("/tmp/quote'd/token file")} scheme ls'`)).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");
   });
 
   it("redacts shell-quoted profile paths before rendering display commands", () => {

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -55,6 +55,8 @@ Status {
     expect(redactCommand("docker rm -f ydb-local")).toBe("docker rm -f ydb-local");
     expect(redactCommand("docker exec -i ydb-local true")).toBe("docker exec -i ydb-local true");
     expect(redactCommand("ssh -i /secret/key host true")).toBe("ssh -i <redacted> host true");
+    expect(redactCommand("bash -lc 'ssh -i /secret/key host true'")).toBe("bash -lc 'ssh -i <redacted> host true'");
+    expect(redactCommand("env ssh -i /secret/key host true")).toBe("env ssh -i <redacted> host true");
     expect(redactCommand("bash -lc 'rm -f /tmp/secret'", ["/tmp/secret"])).toBe("bash -lc 'rm -f <redacted>'");
     expect(redactCommand("bash -lc 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");
     expect(redactCommand("bash -lc\\ 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc\\ 'ydb --token-file <redacted> scheme ls'");
@@ -71,22 +73,33 @@ Status {
   it("redacts shell-quoted profile paths before rendering display commands", () => {
     const authDir = "/tmp/local-ydb-auth/quote'd";
     const authConfigPath = `${authDir}/config.auth.yaml`;
+    const dynamicNodeAuthTokenFile = `${authDir}/dynamic-node-auth.pb`;
     const profile = resolveProfile(ConfigSchema.parse({
       profiles: {
         default: {
-          authConfigPath
+          authConfigPath,
+          dynamicNodeAuthTokenFile
         }
       }
     }));
 
-    const command = new ShellCommandExecutor().display(profile, {
+    const executor = new ShellCommandExecutor();
+    const command = executor.display(profile, {
       command: "bash",
       args: ["-lc", `install -d -m 0700 ${shellQuote(authDir)} && rm -f ${shellQuote(authConfigPath)}`]
     });
+    const mountCommand = executor.display(profile, {
+      command: "docker",
+      args: ["run", "-v", `${dynamicNodeAuthTokenFile}:/run/local-ydb/dynamic-node-auth.pb:ro`]
+    });
 
     expect(command).toBe("bash -lc 'install -d -m 0700 <redacted> && rm -f <redacted>'");
+    expect(mountCommand).toContain("'<redacted>:/run/local-ydb/dynamic-node-auth.pb:ro'");
+    expect(mountCommand).not.toContain("<redacted>/dynamic-node-auth.pb");
     expect(command).not.toContain("/tmp/local-ydb-auth");
+    expect(mountCommand).not.toContain("/tmp/local-ydb-auth");
     expect(command).not.toContain("quote");
+    expect(mountCommand).not.toContain("quote");
   });
 
   it("formats ssh commands with safe defaults", () => {

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -60,9 +60,13 @@ Status {
     expect(redactCommand("ssh -i /secret/key host true")).toBe("ssh -i <redacted> host true");
     expect(redactCommand("ssh -i/secret/key host true")).toBe("ssh -i<redacted> host true");
     expect(redactCommand("/usr/bin/ssh -i /secret/key host true")).toBe("/usr/bin/ssh -i <redacted> host true");
+    expect(redactCommand("scp -i /secret/key file host:/tmp")).toBe("scp -i <redacted> file host:/tmp");
+    expect(redactCommand("sftp -i /secret/key host")).toBe("sftp -i <redacted> host");
     expect(redactCommand("bash -lc 'ssh -i /secret/key host true'")).toBe("bash -lc 'ssh -i <redacted> host true'");
     expect(redactCommand("bash -lc '/usr/bin/ssh -B eth0 -P tag -i /secret/key host true'")).toBe("bash -lc '/usr/bin/ssh -B eth0 -P tag -i <redacted> host true'");
     expect(redactCommand("bash -lc 'ssh -o ProxyCommand=\"ssh -i /secret/key jump\" host true'")).toBe("bash -lc 'ssh -o ProxyCommand=\"ssh -i <redacted> jump\" host true'");
+    expect(redactCommand("bash -lc 'ssh -oProxyCommand=\"ssh -i /secret/key jump\" host true'")).toBe("bash -lc 'ssh -oProxyCommand=\"ssh -i <redacted> jump\" host true'");
+    expect(redactCommand("bash -lc 'ssh -F <(printf x) -i /secret/key host'")).toBe("bash -lc 'ssh -F <(printf x) -i <redacted> host'");
     expect(redactCommand("env ssh -i /secret/key host true")).toBe("env ssh -i <redacted> host true");
     expect(redactCommand("bash -lc 'out=$(ssh -i /secret/key host true)'")).toBe("bash -lc 'out=$(ssh -i <redacted> host true)'");
     expect(redactCommand(`bash -lc 'ssh ${lineContinuation} -i /secret/key host true'`)).toBe(`bash -lc 'ssh ${lineContinuation} -i <redacted> host true'`);

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -62,8 +62,15 @@ Status {
     expect(redactCommand(`bash -lc 'ydb --token-file ${shellQuote("/tmp/quote'd/token file")} scheme ls'`)).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");
   });
 
+  it("redacts every long sensitive flag inside quoted shell scripts", () => {
+    for (const flag of ["--password", "--password-file", "--token-file", "--auth-token-file", "--access-token", "--private-key", "--sa-key-file"]) {
+      expect(redactCommand(`bash -lc 'tool ${flag} /secrets/value done'`)).toBe(`bash -lc 'tool ${flag} <redacted> done'`);
+    }
+  });
+
   it("redacts shell-quoted profile paths before rendering display commands", () => {
-    const authConfigPath = "/tmp/local-ydb-auth/quote'd/config.auth.yaml";
+    const authDir = "/tmp/local-ydb-auth/quote'd";
+    const authConfigPath = `${authDir}/config.auth.yaml`;
     const profile = resolveProfile(ConfigSchema.parse({
       profiles: {
         default: {
@@ -74,10 +81,10 @@ Status {
 
     const command = new ShellCommandExecutor().display(profile, {
       command: "bash",
-      args: ["-lc", `rm -f ${shellQuote(authConfigPath)}`]
+      args: ["-lc", `install -d -m 0700 ${shellQuote(authDir)} && rm -f ${shellQuote(authConfigPath)}`]
     });
 
-    expect(command).toBe("bash -lc 'rm -f <redacted>'");
+    expect(command).toBe("bash -lc 'install -d -m 0700 <redacted> && rm -f <redacted>'");
     expect(command).not.toContain("/tmp/local-ydb-auth");
     expect(command).not.toContain("quote");
   });

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -11,6 +11,7 @@ import {
   type CommandResult,
   type CommandSpec
 } from "../src/index.js";
+import { pathRedactions } from "../src/redactions.js";
 import { ConfigSchema, resolveProfile } from "../src/validation.js";
 
 describe("api client helpers", () => {
@@ -55,7 +56,9 @@ Status {
     expect(redactCommand("docker rm -f ydb-local")).toBe("docker rm -f ydb-local");
     expect(redactCommand("docker exec -i ydb-local true")).toBe("docker exec -i ydb-local true");
     expect(redactCommand("ssh -i /secret/key host true")).toBe("ssh -i <redacted> host true");
+    expect(redactCommand("/usr/bin/ssh -i /secret/key host true")).toBe("/usr/bin/ssh -i <redacted> host true");
     expect(redactCommand("bash -lc 'ssh -i /secret/key host true'")).toBe("bash -lc 'ssh -i <redacted> host true'");
+    expect(redactCommand("bash -lc '/usr/bin/ssh -B eth0 -P tag -i /secret/key host true'")).toBe("bash -lc '/usr/bin/ssh -B eth0 -P tag -i <redacted> host true'");
     expect(redactCommand("env ssh -i /secret/key host true")).toBe("env ssh -i <redacted> host true");
     expect(redactCommand("bash -lc 'rm -f /tmp/secret'", ["/tmp/secret"])).toBe("bash -lc 'rm -f <redacted>'");
     expect(redactCommand("bash -lc 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");
@@ -129,6 +132,12 @@ Status {
 
     expect(tmpCommand).toBe("bash -lc 'echo /tmp/not-secret && cat <redacted>'");
     expect(homeCommand).toBe("bash -lc 'echo /home/alice/not-secret && cat <redacted>'");
+  });
+
+  it("normalizes repeated trailing slashes without broad parent redactions", () => {
+    const slashRun = "/".repeat(5000);
+    expect(pathRedactions(`/tmp${slashRun}root.password`)).toEqual([`/tmp${slashRun}root.password`]);
+    expect(pathRedactions(`/home/alice${slashRun}key`)).toEqual([`/home/alice${slashRun}key`]);
   });
 
   it("formats ssh commands with safe defaults", () => {

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -102,6 +102,35 @@ Status {
     expect(mountCommand).not.toContain("quote");
   });
 
+  it("does not redact broad parent directories for top-level sensitive files", () => {
+    const executor = new ShellCommandExecutor();
+    const tmpProfile = resolveProfile(ConfigSchema.parse({
+      profiles: {
+        default: {
+          rootPasswordFile: "/tmp/root.password"
+        }
+      }
+    }));
+    const tmpCommand = executor.display(tmpProfile, {
+      command: "bash",
+      args: ["-lc", "echo /tmp/not-secret && cat /tmp/root.password"]
+    });
+    const homeProfile = resolveProfile(ConfigSchema.parse({
+      profiles: {
+        default: {
+          rootPasswordFile: "/home/alice/root.password"
+        }
+      }
+    }));
+    const homeCommand = executor.display(homeProfile, {
+      command: "bash",
+      args: ["-lc", "echo /home/alice/not-secret && cat /home/alice/root.password"]
+    });
+
+    expect(tmpCommand).toBe("bash -lc 'echo /tmp/not-secret && cat <redacted>'");
+    expect(homeCommand).toBe("bash -lc 'echo /home/alice/not-secret && cat <redacted>'");
+  });
+
   it("formats ssh commands with safe defaults", () => {
     const profile = resolveProfile(ConfigSchema.parse({
       profiles: {

--- a/packages/core/test/api-client.test.ts
+++ b/packages/core/test/api-client.test.ts
@@ -58,14 +58,17 @@ Status {
     expect(redactCommand("docker rm -f ydb-local")).toBe("docker rm -f ydb-local");
     expect(redactCommand("docker exec -i ydb-local true")).toBe("docker exec -i ydb-local true");
     expect(redactCommand("ssh -i /secret/key host true")).toBe("ssh -i <redacted> host true");
+    expect(redactCommand("ssh -i/secret/key host true")).toBe("ssh -i<redacted> host true");
     expect(redactCommand("/usr/bin/ssh -i /secret/key host true")).toBe("/usr/bin/ssh -i <redacted> host true");
     expect(redactCommand("bash -lc 'ssh -i /secret/key host true'")).toBe("bash -lc 'ssh -i <redacted> host true'");
     expect(redactCommand("bash -lc '/usr/bin/ssh -B eth0 -P tag -i /secret/key host true'")).toBe("bash -lc '/usr/bin/ssh -B eth0 -P tag -i <redacted> host true'");
+    expect(redactCommand("bash -lc 'ssh -o ProxyCommand=\"ssh -i /secret/key jump\" host true'")).toBe("bash -lc 'ssh -o ProxyCommand=\"ssh -i <redacted> jump\" host true'");
     expect(redactCommand("env ssh -i /secret/key host true")).toBe("env ssh -i <redacted> host true");
     expect(redactCommand("bash -lc 'out=$(ssh -i /secret/key host true)'")).toBe("bash -lc 'out=$(ssh -i <redacted> host true)'");
     expect(redactCommand(`bash -lc 'ssh ${lineContinuation} -i /secret/key host true'`)).toBe(`bash -lc 'ssh ${lineContinuation} -i <redacted> host true'`);
     expect(redactCommand("bash -lc 'rm -f /tmp/secret'", ["/tmp/secret"])).toBe("bash -lc 'rm -f <redacted>'");
     expect(redactCommand("bash -lc 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc 'ydb --token-file <redacted> scheme ls'");
+    expect(redactCommand("bash -lc 'cmd=\"ydb --token-file /secret/token\"; echo ok'")).toBe("bash -lc 'cmd=\"ydb --token-file <redacted>\"; echo ok'");
     expect(redactCommand(`bash -lc 'ydb --token-file ${lineContinuation} /secret/token scheme ls'`)).toBe(`bash -lc 'ydb --token-file ${lineContinuation} <redacted> scheme ls'`);
     expect(redactCommand("bash -lc\\ 'ydb --token-file /secrets/token scheme ls'")).toBe("bash -lc\\ 'ydb --token-file <redacted> scheme ls'");
     expect(redactCommand("bash -lc\\ 'rm -f /tmp/secret path'", ["/tmp/secret path"])).toBe("bash -lc\\ 'rm -f <redacted>'");

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -445,6 +445,24 @@ describe("mutating operations", () => {
     expect(response.plannedCommands[1]).toContain("--auth-token-file /run/local-ydb/dynamic-node-auth.pb");
   });
 
+  it("redacts custom dynamic auth token file and parent directory in planned commands", async () => {
+    const shellDisplay = new ShellCommandExecutor();
+    const executor = new RecordingExecutor();
+    executor.display = (profile, spec) => shellDisplay.display(profile, spec);
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+    const response = await writeDynamicNodeAuthConfig(ctx, {
+      sid: "root@builtin",
+      tokenHostPath: "/tmp/local-ydb-auth/quote'd/dynamic-node-auth.pb"
+    });
+
+    expect(response.executed).toBe(false);
+    expect(response.plannedCommands[0]).toContain("install -d -m 0700 <redacted>");
+    expect(response.plannedCommands[0]).toContain("> <redacted>");
+    expect(response.plannedCommands[0]).toContain("chmod 600 <redacted>");
+    expect(response.plannedCommands[0]).not.toContain("/tmp/local-ydb-auth");
+    expect(response.plannedCommands[0]).not.toContain("quote");
+  });
+
   it("plans additional dynamic nodes with unique containers and ports", async () => {
     const executor = new RecordingExecutor();
     const ctx = createContext(undefined, executor, ConfigSchema.parse({

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -458,6 +458,7 @@ describe("mutating operations", () => {
     expect(response.executed).toBe(false);
     expect(response.plannedCommands[0]).toContain("install -d -m 0700 <redacted>");
     expect(response.plannedCommands[0]).toContain("> <redacted>");
+    expect(response.plannedCommands[0]).not.toContain("<redacted>/dynamic-node-auth.pb");
     expect(response.plannedCommands[0]).toContain("chmod 600 <redacted>");
     expect(response.plannedCommands[0]).not.toContain("/tmp/local-ydb-auth");
     expect(response.plannedCommands[0]).not.toContain("quote");

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -1021,9 +1021,9 @@ describe("mutating operations", () => {
     const ctx = createContext(undefined, executor, ConfigSchema.parse({
       profiles: {
         default: {
-          authConfigPath: "/tmp/local-ydb-auth/config.auth.yaml",
-          dynamicNodeAuthTokenFile: "/tmp/local-ydb-auth/dynamic-node-auth.pb",
-          rootPasswordFile: "/tmp/local-ydb-auth/root.password"
+          authConfigPath: "/tmp/local-ydb-auth/quote'd/config.auth.yaml",
+          dynamicNodeAuthTokenFile: "/tmp/local-ydb-auth/quote'd/dynamic-node-auth.pb",
+          rootPasswordFile: "/tmp/local-ydb-auth/quote'd/root.password"
         }
       }
     }));
@@ -1034,9 +1034,9 @@ describe("mutating operations", () => {
 
     expect(artifactCleanupCommands).toHaveLength(3);
     expect(artifactCleanupCommands.every((command) => command.endsWith("'"))).toBe(true);
-    expect(plan).not.toContain("/tmp/local-ydb-auth/config.auth.yaml");
-    expect(plan).not.toContain("/tmp/local-ydb-auth/dynamic-node-auth.pb");
-    expect(plan).not.toContain("/tmp/local-ydb-auth/root.password");
+    expect(plan).not.toContain("/tmp/local-ydb-auth");
+    expect(plan).not.toContain("quote");
+    expect(artifactCleanupCommands.join("\n")).not.toContain("\\''");
     expect(plan).not.toContain("rm -f <redacted>\n");
   });
 

--- a/packages/core/test/operations.test.ts
+++ b/packages/core/test/operations.test.ts
@@ -986,6 +986,60 @@ describe("mutating operations", () => {
     expect(response.removesDumpHostPath).toBe(false);
   });
 
+  it("redacts auth artifact cleanup paths without malformed shell quotes", async () => {
+    const shellDisplay = new ShellCommandExecutor();
+    const executor = new RecordingExecutor();
+    executor.display = (profile, spec) => shellDisplay.display(profile, spec);
+    executor.run = async (_profile, spec) => {
+      const command = executor.display(_profile, spec);
+      executor.commands.push(command);
+      if (command.includes("docker ps -a --format")) {
+        return {
+          command,
+          exitCode: 0,
+          stdout: [
+            JSON.stringify({ Names: "ydb-dyn-example" }),
+            JSON.stringify({ Names: "ydb-local" })
+          ].join("\n"),
+          stderr: "",
+          ok: true,
+          timedOut: false
+        };
+      }
+      if (command.includes("docker volume ls")) {
+        return { command, exitCode: 0, stdout: "ydb-local-data\n", stderr: "", ok: true, timedOut: false };
+      }
+      return {
+        command,
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        ok: true,
+        timedOut: false
+      };
+    };
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({
+      profiles: {
+        default: {
+          authConfigPath: "/tmp/local-ydb-auth/config.auth.yaml",
+          dynamicNodeAuthTokenFile: "/tmp/local-ydb-auth/dynamic-node-auth.pb",
+          rootPasswordFile: "/tmp/local-ydb-auth/root.password"
+        }
+      }
+    }));
+
+    const response = await destroyStack(ctx, { removeAuthArtifacts: true });
+    const plan = response.plannedCommands.join("\n");
+    const artifactCleanupCommands = response.plannedCommands.filter((command) => command.includes("rm -f <redacted>"));
+
+    expect(artifactCleanupCommands).toHaveLength(3);
+    expect(artifactCleanupCommands.every((command) => command.endsWith("'"))).toBe(true);
+    expect(plan).not.toContain("/tmp/local-ydb-auth/config.auth.yaml");
+    expect(plan).not.toContain("/tmp/local-ydb-auth/dynamic-node-auth.pb");
+    expect(plan).not.toContain("/tmp/local-ydb-auth/root.password");
+    expect(plan).not.toContain("rm -f <redacted>\n");
+  });
+
   it("continues docker teardown when tenant removal is blocked by auth failure", async () => {
     const executor = new RecordingExecutor();
     const ctx = createContext(undefined, executor, ConfigSchema.parse({

--- a/packages/core/test/scheme.test.ts
+++ b/packages/core/test/scheme.test.ts
@@ -75,18 +75,30 @@ describe("scheme inspection", () => {
     expect(response.command).toContain("-d /local/example");
   });
 
-  it("adds list flags in the documented CLI order", async () => {
+  it("adds long recursive list flags in the documented CLI order", async () => {
     const executor = new RecordingExecutor();
     const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
 
     const response = await inspectScheme(ctx, {
       path: "/local/example/dir",
       long: true,
+      recursive: true
+    });
+
+    expect(response.command).toContain("scheme ls /local/example/dir -l -R");
+  });
+
+  it("adds recursive one-per-line list flags in the documented CLI order", async () => {
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
+
+    const response = await inspectScheme(ctx, {
+      path: "/local/example/dir",
       recursive: true,
       onePerLine: true
     });
 
-    expect(response.command).toContain("scheme ls /local/example/dir -l -R -1");
+    expect(response.command).toContain("scheme ls /local/example/dir -R -1");
   });
 
   it("describes a scheme object with stats", async () => {
@@ -141,7 +153,8 @@ describe("scheme inspection", () => {
   });
 
   it("rejects unsupported flag combinations", async () => {
-    const ctx = createContext(undefined, new RecordingExecutor(), ConfigSchema.parse({}));
+    const executor = new RecordingExecutor();
+    const ctx = createContext(undefined, executor, ConfigSchema.parse({}));
 
     await expect(inspectScheme(ctx, {
       action: "list",
@@ -152,6 +165,14 @@ describe("scheme inspection", () => {
       action: "describe",
       recursive: true
     })).rejects.toThrow(/only supported when action is list/);
+
+    await expect(inspectScheme(ctx, {
+      action: "list",
+      long: true,
+      onePerLine: true
+    })).rejects.toThrow(/flags -l and -1 are incompatible/);
+
+    expect(executor.commands).toEqual([]);
   });
 
   it("caps stdout and stderr independently", async () => {

--- a/packages/mcp-server/test/tools.test.ts
+++ b/packages/mcp-server/test/tools.test.ts
@@ -534,7 +534,6 @@ describe("mcp tools", () => {
     const result = await callLocalYdbToolForTest("local_ydb_scheme", {
       path: "/local/example/dir",
       recursive: true,
-      long: true,
       onePerLine: true
     }, {
       config: ConfigSchema.parse({}),
@@ -544,7 +543,18 @@ describe("mcp tools", () => {
     expect(result.action).toBe("list");
     expect(result.path).toBe("/local/example/dir");
     expect(result.maxOutputBytes).toBe(65_536);
-    expect(result.command).toContain("scheme ls /local/example/dir -l -R -1");
+    expect(result.command).toContain("scheme ls /local/example/dir -R -1");
+  });
+
+  it("rejects incompatible scheme list flags through the MCP handler", async () => {
+    await expect(callLocalYdbToolForTest("local_ydb_scheme", {
+      path: "/local/example/dir",
+      long: true,
+      onePerLine: true
+    }, {
+      config: ConfigSchema.parse({}),
+      executor: new RecordingExecutor()
+    })).rejects.toThrow(/flags -l and -1 are incompatible/);
   });
 
   it("can describe scheme objects with stats through the MCP handler", async () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two classes of bugs: (1) sensitive-flag redaction producing false positives (`-f` redacting Docker container names, `-i` redacting Docker exec args) and missing true positives (`authConfigPath` and `dynamicNodeAuthTokenFile` not included in profile redactions), and (2) the MCP scheme tool accepting the mutually incompatible `long + onePerLine` flag pair that the YDB CLI rejects at runtime.

- **`auth.ts`**: Removes `-f` and `-i` from the global `SENSITIVE_FLAGS` set; `-i` is now only treated as sensitive when the top-level command is `ssh`. A new `splitTopLevelShellParts` function provides quote-aware word-boundary splitting, and `redactSensitiveFlagValues` deep-scans inside shell-quoted substrings (e.g., the script inside `bash -lc '...'`) for flag-value redaction.
- **`api-client.ts`**: Extends `collectRedactions` to include `authConfigPath` and `dynamicNodeAuthTokenFile`; adds `dedupeRedactions` to include both the raw path and its `shellQuote`d form so paths embedded in shell arguments are matched regardless of quoting style. A new `redactCommandSpec` pre-substitutes sensitive values in command args before the args are converted to a shell string.
- **`scheme.ts`**: Adds an upfront check that throws a clear error when `long` and `onePerLine` are combined, mirroring the CLI's own rejection before any network call is made.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are confined to the display/redaction pipeline and a scheme flag validation; no execution paths are altered.

The redaction overhaul is well-scoped: it fixes false positives in flag handling, adds previously-missing profile fields to the redaction set, and introduces a layered pipeline thoroughly covered by new unit and integration tests including paths with embedded single quotes. The scheme flag change is a simple early guard with matching test coverage. No logic changes were made to the actual command execution path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/auth.ts | Rewrites redact logic with quote-aware word splitting, context-sensitive -i/ssh handling, and deep flag scan inside shell strings; removes false-positive -f and global -i from SENSITIVE_FLAGS |
| packages/core/src/api-client.ts | Adds authConfigPath and dynamicNodeAuthTokenFile to collected redactions, adds dedupeRedactions (raw + shell-quoted forms), and pre-redacts command args before building shell string |
| packages/core/src/operations/scheme.ts | Adds early validation rejecting the long+onePerLine combination, which the YDB CLI rejects at runtime with 'Options -1 and -l are incompatible' |
| packages/core/test/api-client.test.ts | Expands redaction test suite: docker -f/-i false positives, ssh -i, bash -lc quoted scripts, escaped-space tokens, and profile path pre-redaction |
| packages/core/test/operations.test.ts | Integration test verifying auth artifact cleanup commands fully redact paths containing single quotes without malformed shell quoting |
| packages/core/test/scheme.test.ts | Splits the list-flags test into separate long+recursive and recursive+onePerLine cases; adds rejection test for the incompatible long+onePerLine combination |
| packages/mcp-server/test/tools.test.ts | Removes long flag from the existing MCP scheme test and adds an end-to-end rejection test for the incompatible flag pair through the MCP handler |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix shell-quoted sensitive flag redactio..."](https://github.com/astandrik/local-ydb-toolkit/commit/e4233d454b5889b6344b651a309da4f7e5d254c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32752861)</sub>

<!-- /greptile_comment -->