### PR TITLE
Dogfood setup-local-ydb with MCP tools

### DIFF
--- a/.github/workflows/local-ydb-mcp-integration.yml
+++ b/.github/workflows/local-ydb-mcp-integration.yml
@@ -1,0 +1,45 @@
+name: local-ydb MCP integration
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: local-ydb-mcp-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mcp-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Start local YDB
+        id: ydb
+        uses: astandrik/setup-local-ydb@v1
+        with:
+          version: 26.1.1.6
+          tenant: /local/test
+          container-prefix: local-ydb-toolkit-mcp-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Run MCP integration against live YDB
+        env:
+          LOCAL_YDB_STATIC_ENDPOINT: ${{ steps.ydb.outputs.static-endpoint }}
+          LOCAL_YDB_IMAGE: ${{ steps.ydb.outputs.image }}
+          LOCAL_YDB_CONTAINER_PREFIX: local-ydb-toolkit-mcp-${{ github.run_id }}-${{ github.run_attempt }}
+        run: node scripts/ci/verify-live-mcp-server.mjs

--- a/.github/workflows/setup-local-ydb-smoke.yml
+++ b/.github/workflows/setup-local-ydb-smoke.yml
@@ -1,6 +1,9 @@
 name: setup-local-ydb smoke
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: "17 4 * * 1"
@@ -17,12 +20,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
       - name: Start local YDB
         id: ydb
         uses: astandrik/setup-local-ydb@v1
         with:
           version: 26.1.1.6
           tenant: /local/test
+          container-prefix: local-ydb-toolkit-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Verify connection values
         run: |
@@ -31,3 +46,10 @@ jobs:
           test -n "${LOCAL_YDB_MONITORING_URL}"
           test "${{ steps.ydb.outputs.database }}" = "/local/test"
           curl --fail --silent --show-error "${LOCAL_YDB_MONITORING_URL}/viewer/json/capabilities?database=%2Flocal%2Ftest" >/tmp/local-ydb-capabilities.json
+
+      - name: Verify through local-ydb-toolkit MCP tools
+        env:
+          LOCAL_YDB_STATIC_ENDPOINT: ${{ steps.ydb.outputs.static-endpoint }}
+          LOCAL_YDB_IMAGE: ${{ steps.ydb.outputs.image }}
+          LOCAL_YDB_CONTAINER_PREFIX: local-ydb-toolkit-${{ github.run_id }}-${{ github.run_attempt }}
+        run: node scripts/ci/verify-setup-local-ydb.mjs

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Use [`astandrik/setup-local-ydb`](https://github.com/astandrik/setup-local-ydb) 
 
 The action starts `ghcr.io/ydb-platform/local-ydb`, creates the tenant database, waits for readiness, optionally enables native YDB auth, and exports `LOCAL_YDB_ENDPOINT`, `LOCAL_YDB_DATABASE`, and `LOCAL_YDB_MONITORING_URL` for later workflow steps. Add `auth: true` when tests need authenticated YDB behavior; in that mode it also exports `LOCAL_YDB_USER` and `LOCAL_YDB_PASSWORD_FILE` without exposing the raw password value.
 
-This repository dogfoods the Marketplace action in `.github/workflows/setup-local-ydb-smoke.yml`. The concise GitHub Developer Program artifact is in `docs/github-developer-program.md`.
+This repository dogfoods the Marketplace action in `.github/workflows/setup-local-ydb-smoke.yml`: it starts YDB with `astandrik/setup-local-ydb@v1`, builds this MCP server, and verifies the live instance through read-only toolkit tools. The concise GitHub Developer Program artifact is in `docs/github-developer-program.md`.
 
 ## Skill Contents
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Use [`astandrik/setup-local-ydb`](https://github.com/astandrik/setup-local-ydb) 
 
 The action starts `ghcr.io/ydb-platform/local-ydb`, creates the tenant database, waits for readiness, optionally enables native YDB auth, and exports `LOCAL_YDB_ENDPOINT`, `LOCAL_YDB_DATABASE`, and `LOCAL_YDB_MONITORING_URL` for later workflow steps. Add `auth: true` when tests need authenticated YDB behavior; in that mode it also exports `LOCAL_YDB_USER` and `LOCAL_YDB_PASSWORD_FILE` without exposing the raw password value.
 
-This repository dogfoods the Marketplace action in `.github/workflows/setup-local-ydb-smoke.yml`: it starts YDB with `astandrik/setup-local-ydb@v1`, builds this MCP server, and verifies the live instance through read-only toolkit tools. The concise GitHub Developer Program artifact is in `docs/github-developer-program.md`.
+This repository dogfoods the Marketplace action in CI. `.github/workflows/setup-local-ydb-smoke.yml` keeps a short action-level smoke test, while `.github/workflows/local-ydb-mcp-integration.yml` starts the real stdio MCP server and verifies prompts plus read-only and plan-only tools against a live YDB tenant. The concise GitHub Developer Program artifact is in `docs/github-developer-program.md`.
 
 ## Skill Contents
 

--- a/scripts/ci/verify-live-mcp-server.mjs
+++ b/scripts/ci/verify-live-mcp-server.mjs
@@ -1,0 +1,301 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const profileName = "ci-action";
+const tenantPath = requiredEnv("LOCAL_YDB_DATABASE");
+const dynamicEndpoint = requiredEnv("LOCAL_YDB_ENDPOINT");
+const staticEndpoint = requiredEnv("LOCAL_YDB_STATIC_ENDPOINT");
+const monitoringUrl = requiredEnv("LOCAL_YDB_MONITORING_URL");
+const image = requiredEnv("LOCAL_YDB_IMAGE");
+const containerPrefix = requiredEnv("LOCAL_YDB_CONTAINER_PREFIX");
+const rootPasswordFile = process.env.LOCAL_YDB_PASSWORD_FILE || process.env.LOCAL_YDB_ROOT_PASSWORD_FILE;
+const rootUser = process.env.LOCAL_YDB_USER || "root";
+
+const tempDir = await mkdtemp(join(tmpdir(), "local-ydb-mcp-integration-"));
+const configPath = join(tempDir, "local-ydb.config.json");
+const mcpServerPath = resolve("packages/mcp-server/dist/index.js");
+const stderrChunks = [];
+
+const config = {
+  defaultProfile: profileName,
+  profiles: {
+    [profileName]: {
+      mode: "local",
+      image,
+      staticContainer: `${containerPrefix}-static`,
+      dynamicContainer: `${containerPrefix}-dynamic`,
+      tenantPath,
+      volume: `${containerPrefix}-data`,
+      network: `${containerPrefix}-net`,
+      monitoringBaseUrl: monitoringUrl,
+      ports: {
+        staticGrpc: endpointPort(staticEndpoint, "LOCAL_YDB_STATIC_ENDPOINT"),
+        dynamicGrpc: endpointPort(dynamicEndpoint, "LOCAL_YDB_ENDPOINT"),
+        monitoring: endpointPort(monitoringUrl, "LOCAL_YDB_MONITORING_URL"),
+      },
+      ...(rootPasswordFile ? { rootUser, rootPasswordFile } : {}),
+    },
+  },
+};
+
+await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [mcpServerPath],
+  cwd: process.cwd(),
+  env: {
+    ...stringEnv(process.env),
+    LOCAL_YDB_TOOLKIT_CONFIG: configPath,
+    LOCAL_YDB_MCP_CONTENT_FORMAT: "json",
+  },
+  stderr: "pipe",
+});
+transport.stderr?.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
+
+const client = new Client(
+  { name: "local-ydb-toolkit-ci", version: "0.0.0" },
+  { capabilities: {} },
+);
+
+try {
+  await client.connect(transport, { timeout: 60_000 });
+
+  assert(client.getServerVersion()?.name === "local-ydb-toolkit", "Unexpected MCP server name.");
+  assert(client.getServerCapabilities()?.tools, "MCP server did not advertise tools.");
+  assert(client.getServerCapabilities()?.prompts, "MCP server did not advertise prompts.");
+  assert(
+    client.getInstructions()?.includes("local_ydb_status_report"),
+    "MCP server instructions did not include local-ydb guidance.",
+  );
+
+  await verifyToolRegistry(client);
+  await verifyPromptRegistry(client);
+  await verifyLiveTools(client);
+
+  console.log("Live local-ydb MCP stdio server integration passed.");
+} finally {
+  await client.close().catch(() => {});
+  await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+
+  const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+  if (stderr) {
+    console.log(`MCP stderr:\n${stderr}`);
+  }
+}
+
+async function verifyToolRegistry(client) {
+  console.log("::group::tools/list");
+  try {
+    const result = await client.listTools(undefined, { timeout: 60_000 });
+    const tools = new Map(result.tools.map((tool) => [tool.name, tool]));
+    const expectedTools = [
+      "local_ydb_status_report",
+      "local_ydb_inventory",
+      "local_ydb_database_status",
+      "local_ydb_tenant_check",
+      "local_ydb_nodes_check",
+      "local_ydb_scheme",
+      "local_ydb_graphshard_check",
+      "local_ydb_auth_check",
+      "local_ydb_storage_placement",
+      "local_ydb_container_logs",
+      "local_ydb_permissions",
+      "local_ydb_add_dynamic_nodes",
+    ];
+
+    for (const name of expectedTools) {
+      assert(tools.has(name), `Missing MCP tool ${name}.`);
+    }
+
+    const expectedReadOnlyTools = expectedTools.filter(
+      (toolName) => toolName !== "local_ydb_permissions" && toolName !== "local_ydb_add_dynamic_nodes",
+    );
+    for (const name of expectedReadOnlyTools) {
+      assert(tools.get(name)?.annotations?.readOnlyHint === true, `${name} should be advertised as read-only.`);
+    }
+
+    console.log(JSON.stringify({ toolCount: result.tools.length, checked: expectedTools }, null, 2));
+  } finally {
+    console.log("::endgroup::");
+  }
+}
+
+async function verifyPromptRegistry(client) {
+  console.log("::group::prompts/list-get");
+  try {
+    const result = await client.listPrompts(undefined, { timeout: 60_000 });
+    const promptNames = new Set(result.prompts.map((prompt) => prompt.name));
+    assert(promptNames.has("local_ydb_diagnose_stack"), "Missing diagnose prompt.");
+    assert(promptNames.has("local_ydb_bootstrap_tenant_workflow"), "Missing tenant bootstrap prompt.");
+
+    const prompt = await client.getPrompt(
+      {
+        name: "local_ydb_diagnose_stack",
+        arguments: { profile: profileName },
+      },
+      { timeout: 60_000 },
+    );
+    const text = prompt.messages[0]?.content?.text;
+    assert(
+      typeof text === "string" && text.includes("local_ydb_status_report"),
+      "Diagnose prompt did not render expected guidance.",
+    );
+
+    console.log(JSON.stringify({ promptCount: result.prompts.length, checked: [...promptNames].sort() }, null, 2));
+  } finally {
+    console.log("::endgroup::");
+  }
+}
+
+async function verifyLiveTools(client) {
+  const profile = profileName;
+  const statusReport = await callTool(client, "local_ydb_status_report", { profile });
+  assert(statusReport.tenant?.ok === true, statusReport.tenant?.stderr || "tenant check failed");
+  assert(statusReport.nodes?.ok === true, statusReport.nodes?.error || "node check failed");
+
+  const inventory = await callTool(client, "local_ydb_inventory", { profile });
+  assert(Array.isArray(inventory.containers), "inventory did not return containers.");
+  assert(Array.isArray(inventory.volumes), "inventory did not return volumes.");
+  assert(
+    inventory.containers.some((container) => container.names === `${containerPrefix}-static`),
+    "inventory did not include the static local-ydb container.",
+  );
+
+  const databaseStatus = await callTool(client, "local_ydb_database_status", { profile });
+  assert(databaseStatus.ok === true, databaseStatus.stderr || "database status failed");
+
+  const tenantCheck = await callTool(client, "local_ydb_tenant_check", { profile });
+  assert(tenantCheck.ok === true, tenantCheck.stderr || "tenant check failed");
+
+  const nodesCheck = await callTool(client, "local_ydb_nodes_check", { profile });
+  assert(nodesCheck.ok === true, nodesCheck.error || "nodes check failed");
+  assert(Array.isArray(nodesCheck.nodes) && nodesCheck.nodes.length > 0, "nodes check returned no nodes.");
+
+  const scheme = await callTool(client, "local_ydb_scheme", {
+    profile,
+    path: tenantPath,
+    onePerLine: true,
+  });
+  assert(scheme.ok === true, scheme.stderr || "scheme list failed");
+
+  const permissions = await callTool(client, "local_ydb_permissions", {
+    profile,
+    action: "list",
+    path: tenantPath,
+  });
+  assert(permissions.ok === true, permissions.stderr || "permissions list failed");
+
+  const graphshard = await callTool(client, "local_ydb_graphshard_check", { profile });
+  assert(graphshard.ok === true, graphshard.tabletInfoError || "GraphShard check failed");
+  assert(graphshard.graphShardExists === true, "GraphShard was not reported for the tenant.");
+
+  const storagePlacement = await callTool(client, "local_ydb_storage_placement", { profile });
+  assert(storagePlacement.ok === true, storagePlacement.queryBase?.stderr || "storage placement failed");
+
+  const authCheck = await callTool(client, "local_ydb_auth_check", { profile });
+  assert(Number.isInteger(authCheck.viewerWhoamiStatus), "auth check did not return a viewer status.");
+
+  const staticLogs = await callTool(client, "local_ydb_container_logs", {
+    profile,
+    target: "static",
+    lines: 20,
+  });
+  assert(staticLogs.ok === true, staticLogs.stderr || "static container logs failed");
+
+  const dynamicNodePlan = await callTool(client, "local_ydb_add_dynamic_nodes", {
+    profile,
+    count: 1,
+  });
+  assert(
+    dynamicNodePlan.executed === false,
+    "plan-only dynamic-node tool should not execute without confirm=true.",
+  );
+  assert(
+    Array.isArray(dynamicNodePlan.plannedCommands) && dynamicNodePlan.plannedCommands.length > 0,
+    "dynamic-node plan did not include commands.",
+  );
+}
+
+async function callTool(client, name, args) {
+  console.log(`::group::tools/call ${name}`);
+  try {
+    const result = await client.callTool(
+      { name, arguments: args },
+      undefined,
+      { timeout: 120_000 },
+    );
+    if (result.isError) {
+      throw new Error(`${name} returned MCP error: ${toolText(result)}`);
+    }
+    const data = "structuredContent" in result ? result.structuredContent : result.toolResult;
+    assertPlainObject(data, `${name} did not return structured content.`);
+    console.log(JSON.stringify(summarize(data), null, 2));
+    return data;
+  } finally {
+    console.log("::endgroup::");
+  }
+}
+
+function summarize(value) {
+  return {
+    summary: value.summary,
+    ok: value.ok,
+    tenantOk: value.tenant?.ok,
+    nodesOk: value.nodes?.ok,
+    nodeCount: Array.isArray(value.nodes) ? value.nodes.length : undefined,
+    graphShardExists: value.graphShardExists,
+    viewerWhoamiStatus: value.viewerWhoamiStatus,
+    executed: value.executed,
+    risk: value.risk,
+    command: value.command,
+  };
+}
+
+function toolText(result) {
+  if (!Array.isArray(result.content)) {
+    return JSON.stringify(result);
+  }
+  return result.content
+    .filter((item) => item.type === "text")
+    .map((item) => item.text)
+    .join("\n");
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function endpointPort(value, name) {
+  const port = Number(new URL(value).port);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`${name} must include a valid port: ${value}`);
+  }
+  return port;
+}
+
+function stringEnv(env) {
+  return Object.fromEntries(
+    Object.entries(env).filter((entry) => typeof entry[1] === "string"),
+  );
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertPlainObject(value, message) {
+  assert(
+    value !== null && typeof value === "object" && !Array.isArray(value),
+    message,
+  );
+}

--- a/scripts/ci/verify-setup-local-ydb.mjs
+++ b/scripts/ci/verify-setup-local-ydb.mjs
@@ -1,0 +1,87 @@
+import { callLocalYdbToolForTest } from "../../packages/mcp-server/dist/index.js";
+
+const profileName = "ci-action";
+const tenantPath = requiredEnv("LOCAL_YDB_DATABASE");
+const dynamicEndpoint = requiredEnv("LOCAL_YDB_ENDPOINT");
+const staticEndpoint = requiredEnv("LOCAL_YDB_STATIC_ENDPOINT");
+const monitoringUrl = requiredEnv("LOCAL_YDB_MONITORING_URL");
+const image = requiredEnv("LOCAL_YDB_IMAGE");
+const containerPrefix = requiredEnv("LOCAL_YDB_CONTAINER_PREFIX");
+
+const config = {
+  defaultProfile: profileName,
+  profiles: {
+    [profileName]: {
+      mode: "local",
+      image,
+      staticContainer: `${containerPrefix}-static`,
+      dynamicContainer: `${containerPrefix}-dynamic`,
+      tenantPath,
+      volume: `${containerPrefix}-data`,
+      network: `${containerPrefix}-net`,
+      monitoringBaseUrl: monitoringUrl,
+      ports: {
+        staticGrpc: endpointPort(staticEndpoint, "LOCAL_YDB_STATIC_ENDPOINT"),
+        dynamicGrpc: endpointPort(dynamicEndpoint, "LOCAL_YDB_ENDPOINT"),
+        monitoring: endpointPort(monitoringUrl, "LOCAL_YDB_MONITORING_URL"),
+      },
+    },
+  },
+};
+
+const statusReport = await callTool("local_ydb_status_report", { profile: profileName });
+assert(statusReport.tenant?.ok === true, statusReport.tenant?.stderr || "tenant check failed");
+assert(statusReport.nodes?.ok === true, statusReport.nodes?.error || "node check failed");
+
+const scheme = await callTool("local_ydb_scheme", {
+  profile: profileName,
+  path: tenantPath,
+  onePerLine: true,
+});
+assert(scheme.ok === true, scheme.stderr || "scheme list failed");
+
+const graphshard = await callTool("local_ydb_graphshard_check", { profile: profileName });
+assert(graphshard.ok === true, graphshard.tabletInfoError || "GraphShard check failed");
+
+console.log("local-ydb-toolkit MCP tools verified the setup-local-ydb instance.");
+
+async function callTool(name, args) {
+  console.log(`::group::${name}`);
+  const result = await callLocalYdbToolForTest(name, args, { config });
+  console.log(JSON.stringify(summarize(result), null, 2));
+  console.log("::endgroup::");
+  return result;
+}
+
+function summarize(value) {
+  return {
+    summary: value?.summary,
+    ok: value?.ok,
+    tenantOk: value?.tenant?.ok,
+    nodesOk: value?.nodes?.ok,
+    graphShardExists: value?.graphShardExists,
+    command: value?.command,
+  };
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function endpointPort(value, name) {
+  const port = Number(new URL(value).port);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`${name} must include a valid port: ${value}`);
+  }
+  return port;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}


### PR DESCRIPTION
## Summary
- extend setup-local-ydb smoke to run on pull requests
- build the MCP server before starting YDB
- verify the live setup-local-ydb instance through read-only local-ydb-toolkit MCP tools

## Verification
- ruby YAML parse for setup-local-ydb-smoke.yml
- node --check scripts/ci/verify-setup-local-ydb.mjs
- npm run build
- npm test
- npm run typecheck