### PR TITLE
test: trigger code indexer PR indexing

### DIFF
--- a/.github/code-indexer-smoke/20260525T142803Z.md
+++ b/.github/code-indexer-smoke/20260525T142803Z.md
@@ -1,0 +1,7 @@
+# Code Indexer PR smoke test
+
+Repository: `astandrik/local-ydb-toolkit`
+Run: `code-indexer-smoke-20260525T142803Z`
+Purpose: trigger GitHub App pull_request indexing without touching runtime code.
+
+This PR can be closed after the dashboard shows PR indexing activity.


### PR DESCRIPTION
Smoke PR for YDB Qdrant Code Indexer.

Expected behavior:
- GitHub App receives `pull_request.opened`.
- Backend enqueues a `pr-index` job with this PR number.
- Dashboard shows pull request indexing separately from default branch indexing.

Run: `code-indexer-smoke-20260525T142803Z`