### PR TITLE
test: trigger extra code indexer PR indexing 2

### DIFF
--- a/.github/code-indexer-smoke/20260525T144503Z-extra-2.md
+++ b/.github/code-indexer-smoke/20260525T144503Z-extra-2.md
@@ -1,0 +1,6 @@
+# Code Indexer extra PR smoke test
+
+Repository: `astandrik/local-ydb-toolkit`
+Run: `code-indexer-smoke-extra-20260525T144503Z`
+Case: `2`
+Purpose: keep multiple pull request indexing jobs visible in the dashboard.


### PR DESCRIPTION
Extra smoke PR for YDB Qdrant Code Indexer.

Expected behavior: dashboard keeps default branch metadata and lists PR indexing jobs separately.

Run: `code-indexer-smoke-extra-20260525T144503Z`
Case: `2`