### PR TITLE
Remove Code Indexer E2E marker

### DIFF
--- a/docs/code-indexer-public-saas-e2e-2026-05-25.md
+++ b/docs/code-indexer-public-saas-e2e-2026-05-25.md
@@ -1,5 +1,0 @@
-# Code indexer public SaaS E2E
-
-Updated at 2026-05-25T11:12:15Z for ydb-qdrant code-indexer verification.
-
-Search phrase: public SaaS hosted MCP indexing verification.


### PR DESCRIPTION
Removes the temporary Code Indexer public SaaS E2E marker document that was created only to verify repository indexing.\n\nVerification:\n- npm test